### PR TITLE
Add FAU FCS API support

### DIFF
--- a/docs/unified.json
+++ b/docs/unified.json
@@ -185,19 +185,10 @@
       "source": "РИА СТК"
     },
     {
-      "id": "804a4e2b6da19aefe3edd98ae4808676e6080c63969112c321f212d057623dd9",
-      "url": "https://www.pnp.ru/economics/ekspert-dopustil-chto-zapret-na-vyvoz-zolota-rasprostranyat-na-ukrasheniya.html",
-      "title": "Эксперт допустил, что запрет на вывоз золота распространят на украшения",
-      "date_published": "2025-09-23T00:41:00+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Парламентская газета: Экономика"
-    },
-    {
       "id": "6314cf1303deaa05ddb9ebb1e70cc4256847788c71f164dcece19bc4760e1c7b",
       "url": "https://www.pnp.ru/economics/ekspert-neftyanaya-dedollarizaciya-proiskhodit-v-ramkakh-trenda-vo-vneshney-torgovle.html",
       "title": "Эксперт: Нефтяная «дедолларизация» происходит в рамках тренда во внешней торговле",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -206,7 +197,7 @@
       "id": "9872f9329bd4dfdd4f06d6fba249b3ee990b0de06d4457f8bb78787bbaa0cdbd",
       "url": "https://www.pnp.ru/economics/syrevye-tovary-s-dragmetallami-nachnut-eksportirovat-iz-rossii.html",
       "title": "Сырьевые товары с драгметаллами начнут экспортировать из России",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -215,7 +206,7 @@
       "id": "93341dfab2ae9a86b7a9adb179d76dde65e5876a97401f1e26748df11a3a222c",
       "url": "https://www.pnp.ru/economics/v-rossii-vyyavili-bolee-12-tysyach-narusheniy-pravil-markirovki.html",
       "title": "В России выявили более 12 тысяч нарушений правил маркировки",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -224,7 +215,7 @@
       "id": "037b0cc5816464562ec2d2d9af8e7630be84e994b46796713efc02a234aab8b9",
       "url": "https://www.pnp.ru/economics/cb-srednyaya-zarplata-po-rossii-v-2025-godu-rastet-na-15.html",
       "title": "ЦБ: Средняя зарплата по России в 2025 году растет на 15%",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -233,7 +224,7 @@
       "id": "0483e79928e9967cc3da068a61e13472e40575a4ecb9011ae6b24a6e3d88e1db",
       "url": "https://www.pnp.ru/economics/senator-timchenko-skvoznaya-model-kontrolya-povysit-effektivnost-nadzora.html",
       "title": "Сенатор Тимченко: Сквозная модель контроля повысит эффективность надзора",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -242,7 +233,7 @@
       "id": "a4f03e06a95da4b5af4db6ed11f1ad5fdb696745afde1541d2be22e679fa9c02",
       "url": "https://www.pnp.ru/economics/iran-i-rossiya-podpishut-soglashenie-o-stroitelstve-novykh-atomnykh-energoblokov.html",
       "title": "Иран и Россия подпишут соглашение о строительстве новых атомных энергоблоков",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -251,7 +242,7 @@
       "id": "b1d0420586552033ad0a7aca9ae28f984c6805d7e604621ba94cc7e36e108361",
       "url": "https://www.pnp.ru/economics/v-sovfede-predlozhili-sozdat-rabochuyu-gruppu-po-modernizacii-zhkkh-na-chukotke.html",
       "title": "В Совфеде предложили создать рабочую группу по модернизации ЖКХ на Чукотке",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -260,7 +251,7 @@
       "id": "2af21eda1512a0e4994648f137e689e8eca14f95b9b33497bb7db0473fc0cd3b",
       "url": "https://www.pnp.ru/economics/minpromtorg-sobiraetsya-zhestche-kontrolirovat-proizvodstvo-noutbukov-i-smartfonov.html",
       "title": "Минпромторг собирается жестче контролировать производство ноутбуков и смартфонов",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -269,7 +260,7 @@
       "id": "6834911f1e9946792cf777717b7633a1a0c277bff9d30c848293bd71783c4f11",
       "url": "https://www.pnp.ru/economics/senator-bezrabotica-v-rossii-ostanetsya-rekordno-nizkoy-v-2026-godu.html",
       "title": "Сенатор: Безработица в России останется рекордно низкой в 2026 году",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -278,7 +269,7 @@
       "id": "b9e83a02208c7518c715acbb153e6eb81175d62576deb6f12570b0a2fda3ed18",
       "url": "https://www.pnp.ru/economics/kreditnye-kanikuly-dlya-mnogodetnykh-stanut-v-tri-raza-dlinnee.html",
       "title": "Кредитные каникулы для многодетных станут в три раза длиннее",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -287,7 +278,7 @@
       "id": "1c6a8f6a0a1e81eeadef69328ef6b5e8bf09a9170fb4803a6663f1b777a71001",
       "url": "https://www.pnp.ru/economics/rabotu-inspektora-khotyat-poruchit-iskusstvennomu-intellektu.html",
       "title": "Работу инспектора хотят поручить искусственному интеллекту",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -296,7 +287,7 @@
       "id": "928af8ace63e137bb43a36b871047b66079ddd73f8087fb6fc20d1c2a5fb5bcc",
       "url": "https://www.pnp.ru/economics/rossiyskiy-rynok-akciy-zamedlil-snizhenie-posle-zayavleniy-putina-po-dsnv.html",
       "title": "Российский рынок акций замедлил снижение после заявлений Путина о ДСНВ",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -305,7 +296,7 @@
       "id": "67cbd9a143dba4e1dd209af6ccd40b8c231b8fee0193ab0d29a4060329bf0852",
       "url": "https://www.pnp.ru/economics/komitet-gosdumy-odobril-zakonoproekt-ob-ipotechnykh-kanikulakh-dlya-semey-s-detmi.html",
       "title": "Комитет Госдумы одобрил законопроект об ипотечных каникулах для семей с детьми",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -314,7 +305,7 @@
       "id": "7054cfa076b936c09cc93dc75ec7ad351374f2b98a9c31bbe52119b65329920a",
       "url": "https://www.pnp.ru/economics/v-rossii-startovala-monetnaya-nedelya-po-obmenu-melochi-na-banknoty.html",
       "title": "В России стартовала «Монетная неделя» по обмену мелочи на банкноты",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -323,7 +314,7 @@
       "id": "8d597164601af63894b22ea0913e589cc1d8f3edea0f3d231edead45d4cc4dcf",
       "url": "https://www.pnp.ru/economics/v-moskve-pri-oplate-poezdki-po-biometrii-do-konca-goda-budet-polozhen-keshbek.html",
       "title": "В Москве при оплате поездки по биометрии будет положен кешбэк",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -332,7 +323,7 @@
       "id": "949653c00ad43ab95486b5c01b07864639c4fb4acf11975c64fa72c1f3d202a4",
       "url": "https://www.pnp.ru/economics/sber-zapustil-platformu-socialnykh-nalogovykh-vychetov.html",
       "title": "«Сбер» запустил платформу социальных налоговых вычетов",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -341,7 +332,16 @@
       "id": "5a701a136bc238c2445bab8aff32a81a456a658108eccb37721c29b8e7c073af",
       "url": "https://www.pnp.ru/economics/aksenov-semi-pogibshikh-pri-atake-bpla-na-foros-poluchat-po-15-mln-rubley.html",
       "title": "Аксенов: Семьи погибших при атаке БПЛА на Форос получат по 1,5 млн рублей",
-      "date_published": "2025-09-23T00:41:00+03:00",
+      "date_published": "2025-09-23T01:45:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Парламентская газета: Экономика"
+    },
+    {
+      "id": "804a4e2b6da19aefe3edd98ae4808676e6080c63969112c321f212d057623dd9",
+      "url": "https://www.pnp.ru/economics/ekspert-dopustil-chto-zapret-na-vyvoz-zolota-rasprostranyat-na-ukrasheniya.html",
+      "title": "Эксперт допустил, что запрет на вывоз золота распространят на украшения",
+      "date_published": "2025-09-23T01:44:00+03:00",
       "content_text": null,
       "tags": [],
       "source": "Парламентская газета: Экономика"
@@ -509,109 +509,10 @@
       "source": "Российская газета: Экономика"
     },
     {
-      "id": "74644760eed2bc71dc1221b068f4025336e29b779f62ec2d13b333c79faabc45",
-      "url": "https://stroygaz.ru/news/kadry/stroitelstvo-stalo-samoy-vysokooplachivaemoy-otraslyu-promyshlennosti-etim-letom/",
-      "title": "Строительство стало самой высокооплачиваемой отраслью промышленности этим летом - Строительная газета",
-      "date_published": "2025-09-22T19:21:59.615966+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "3437a7ad2453ce93246e3dcbef04e37e4b64f66035b8c27a7f4e8c191592bba6",
-      "url": "https://stroygaz.ru/news/architecture/myasnuyu-promyshlennost-na-vdnkh-peredelayut-v-muzey-gradostroitelstva-moskvy-/",
-      "title": "«Мясную промышленность» на ВДНХ переделают в Музей градостроительства Москвы  - Строительная газета",
-      "date_published": "2025-09-22T19:21:59.483304+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "53f109861d43509dce464331f0ec5b4e2bc24f5c91bb01c1fd344d9d13544cb3",
-      "url": "https://stroygaz.ru/news/info-partners-news/vserossiyskiy-forum-praktikum-dlya-developerov-forcities-xi-proydet-etoy-osenyu-v-moskve-/",
-      "title": "Всероссийский форум-практикум для девелоперов FORCITIES XI пройдет этой осенью в Москве  - Строительная газета",
-      "date_published": "2025-09-22T19:21:57.061371+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "7b362dcb782cc3dc68fe95dbe9b80d1a2b605168ac6e3ad82521406a7ddae0c2",
-      "url": "https://stroygaz.ru/news/?VOTE_ID=77&view_result=Y",
-      "title": "Новости - Строительная газета",
-      "date_published": "2025-09-22T19:21:54.783670+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "15f0ee7dc7b4e6c9c6f78c595c7fccfaee0786436d06db8a5bec2391c3d5c8f5",
-      "url": "https://stroygaz.ru/news/",
-      "title": "Новости - Строительная газета",
-      "date_published": "2025-09-22T19:21:52.308895+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "72008417ebaf1f42825d4d1e59127b485b22b08f6cbeecc4f0498ae8982d6266",
-      "url": "https://stroygaz.ru/news/projection/bolee-trekh-tysyach-territoriy-blagoustroili-v-rossii-s-nachala-goda/",
-      "title": "Более трех тысяч территорий благоустроили в России с начала года - Строительная газета",
-      "date_published": "2025-09-22T19:21:49.971609+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "1e0af213e646446f6253a34aa6cceb359da4201c483d01c3f6ba37332050b327",
-      "url": "https://stroygaz.ru/news/projection/v-novomoskovske-za-pyat-let-planiruetsya-sozdat-promyshlenno-gorodskuyu-ekosistemu-na-osnove-printsi/",
-      "title": "В Новомосковске за пять лет планируется создать промышленно-городскую экосистему на основе принципов ESG - Строительная газета",
-      "date_published": "2025-09-22T19:21:47.522497+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "2057a10e15d2a29e89eec28db4c2ae3ca8090f22dffb2fe3ee17b756cbee0761",
-      "url": "https://stroygaz.ru/news/technologies/",
-      "title": "Технологии - Строительная газета",
-      "date_published": "2025-09-22T19:21:45.180422+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "b518803ee2ff5201fd75fae4b2adc635c216f43c082e5908e11bc00d6bb898ed",
-      "url": "https://stroygaz.ru/news/construction/",
-      "title": "Строительство - Строительная газета",
-      "date_published": "2025-09-22T19:21:42.678099+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "4ea5ee7bd014cf78f4101bb907a8bf9fbf12e9baf25c85c62e149b4aa6900921",
-      "url": "https://stroygaz.ru/news/srochno-v-nomer/",
-      "title": "СРОчно в номер - Строительная газета",
-      "date_published": "2025-09-22T19:21:40.272516+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "161fd4e7710492a8df0565ed2695c8d4f9666f9b7e29c7582e21e5bb5fdaf126",
-      "url": "https://stroygaz.ru/news/samoe-samoe/",
-      "title": "Самое-самое - Строительная газета",
-      "date_published": "2025-09-22T19:21:37.787499+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
       "id": "7f984853ae562d96f48479926a95d9c5b8f95864e31c360a7aef65c1fc061b08",
       "url": "https://stroygaz.ru/news/regulation/",
       "title": "Регулирование - Строительная газета",
-      "date_published": "2025-09-22T19:21:35.408609+03:00",
+      "date_published": "2025-09-22T19:21:57.915925+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -620,7 +521,7 @@
       "id": "fadbda2f14f29de9d3829c98e18349a8e34e2f74900fb6dd00b3d1b189bf9c4c",
       "url": "https://stroygaz.ru/news/official/",
       "title": "Официально - Строительная газета",
-      "date_published": "2025-09-22T19:21:32.868620+03:00",
+      "date_published": "2025-09-22T19:21:55.476900+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -629,7 +530,7 @@
       "id": "733f586a99725c55952fbb3821a30b6d27e0734e1bc56f0395bfce8d702e677c",
       "url": "https://stroygaz.ru/news/info-partners-news/",
       "title": "Новости инфопартнеров - Строительная газета",
-      "date_published": "2025-09-22T19:21:30.438538+03:00",
+      "date_published": "2025-09-22T19:21:53.050074+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -638,7 +539,7 @@
       "id": "bea08becd7d36dd3eafbae7efd83c890732814ba0395efcec72d57a63e202495",
       "url": "https://stroygaz.ru/news/materials/",
       "title": "Материалы / Техника - Строительная газета",
-      "date_published": "2025-09-22T19:21:27.905779+03:00",
+      "date_published": "2025-09-22T19:21:50.655516+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -647,7 +548,7 @@
       "id": "171ca96bc673d32069c0424a8dc2c48cc56383013cd2ff1263c89dbb2cddb1b4",
       "url": "https://stroygaz.ru/news/commercial/",
       "title": "Коммерческая недвижимость - Строительная газета",
-      "date_published": "2025-09-22T19:21:25.552469+03:00",
+      "date_published": "2025-09-22T19:21:48.240413+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -656,7 +557,7 @@
       "id": "3c658b3a3196396a5dcb709c06b97c54309883b79f1effd9e6c7aba27ce316ed",
       "url": "https://stroygaz.ru/news/infrastructure/",
       "title": "Инфраструктура - Строительная газета",
-      "date_published": "2025-09-22T19:21:23.232954+03:00",
+      "date_published": "2025-09-22T19:21:45.718708+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -665,7 +566,7 @@
       "id": "1647e8e678056bd7252084d868eb67c7e4021d954b0e81f2ef897dd82a7c3e55",
       "url": "https://stroygaz.ru/news/projection/",
       "title": "Городская среда - Строительная газета",
-      "date_published": "2025-09-22T19:21:20.889293+03:00",
+      "date_published": "2025-09-22T19:21:43.247936+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -674,7 +575,7 @@
       "id": "614a82226bcf527ee1d11c119b6407e5b37db0c552862d647ebe9e189392deca",
       "url": "https://stroygaz.ru/news/dwelling/v-2026-godu-regiony-stolknutsya-s-korrektirovkoy-tsen-na-rynke-novostroek-ekspert/",
       "title": "В 2026 году регионы столкнутся с корректировкой цен на рынке новостроек — эксперт - Строительная газета",
-      "date_published": "2025-09-22T19:21:19.134395+03:00",
+      "date_published": "2025-09-22T19:21:41.571382+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -683,7 +584,7 @@
       "id": "1e7001b8ff325f76135ca488052a48bd5e3663b891a7cdb8675cfda0b20b0a70",
       "url": "https://stroygaz.ru/news/architecture/",
       "title": "Архитектура - Строительная газета",
-      "date_published": "2025-09-22T19:21:18.484980+03:00",
+      "date_published": "2025-09-22T19:21:40.844825+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -692,7 +593,7 @@
       "id": "12538a56ecf5cc5f6a1b605d420ae81088cfe8eb9f1583f2e908a3f078589ed5",
       "url": "https://stroygaz.ru/news/infrastructure/pravitelstvo-vydelit-sredstva-na-uluchshenie-ekologii-vodoemov-v-trekh-regionakh/",
       "title": "Правительство выделит средства на улучшение экологии водоемов в трех регионах - Строительная газета",
-      "date_published": "2025-09-22T19:21:16.737012+03:00",
+      "date_published": "2025-09-22T19:21:39.202275+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -701,7 +602,7 @@
       "id": "a1b25468813494cd4993a6748d6a1927248dc61e2814e7cb0ca4f90547182be5",
       "url": "https://stroygaz.ru/news/dwelling/v-rossii-vyros-interes-k-pokupke-vtorichnykh-kvartir-/",
       "title": "В России вырос интерес к покупке вторичных квартир  - Строительная газета",
-      "date_published": "2025-09-22T19:21:16.063171+03:00",
+      "date_published": "2025-09-22T19:21:38.424408+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -710,7 +611,7 @@
       "id": "bd33578c527df667543f70d5933797edc8a698678753aade587e9c740c9360a8",
       "url": "https://stroygaz.ru/news/infrastructure/bolee-1-5-tysyach-edinits-obshchestvennogo-transporta-postupit-v-regiony-v-etom-godu-po-natsproektu/",
       "title": "Более 1,5 тысяч единиц общественного транспорта поступит в регионы в этом году по нацпроекту - Строительная газета",
-      "date_published": "2025-09-22T19:21:14.143621+03:00",
+      "date_published": "2025-09-22T19:21:36.709057+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -719,7 +620,7 @@
       "id": "327ac275b3d99a5d8b2f6e96f300057f7c6100d68567b44b06b34c09f87c247c",
       "url": "https://stroygaz.ru/news/projection/na-yuge-moskvy-poyavitsya-novaya-naberezhnaya-/",
       "title": "На юге Москвы появится новая набережная  - Строительная газета",
-      "date_published": "2025-09-22T19:21:13.674282+03:00",
+      "date_published": "2025-09-22T19:21:35.960162+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -728,7 +629,7 @@
       "id": "829517a3d38d8f391f82f73b9227f950e8d8b8f0e54e44490908678908d66b01",
       "url": "https://stroygaz.ru/news/dwelling/bolee-poloviny-arendatorov-kvartir-v-domakh-pod-snos-planiruyut-pereselitsya-v-novostroyki-po-renova/",
       "title": "Более половины арендаторов квартир в домах под снос планируют переселиться в новостройки по реновации - Строительная газета",
-      "date_published": "2025-09-22T19:21:11.676468+03:00",
+      "date_published": "2025-09-22T19:21:34.197826+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -737,7 +638,7 @@
       "id": "283c7e5eb3def4ec9a71b57abc7aeefbfeb14d2340a0c902f3e65a438a12e5d7",
       "url": "https://stroygaz.ru/news/dwelling/frunzenskaya-naberezhnaya-lidiruet-po-predlozheniyam-nedvizhimosti-u-vody-v-tsentre-moskvy/",
       "title": "Фрунзенская набережная лидирует по предложениям недвижимости у воды в центре Москвы - Строительная газета",
-      "date_published": "2025-09-22T19:21:11.360011+03:00",
+      "date_published": "2025-09-22T19:21:33.522947+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -746,7 +647,7 @@
       "id": "b7eae444f212d270b89f62314a8b8f97cc970358a63c647def1ef5bbad4c48b7",
       "url": "https://stroygaz.ru/news/dwelling/na-vtorichnom-rynke-peterburga-sokratilos-predlozhenie-i-vyrosli-tseny/",
       "title": "На вторичном рынке Петербурга сократилось предложение и выросли цены - Строительная газета",
-      "date_published": "2025-09-22T19:21:09.322599+03:00",
+      "date_published": "2025-09-22T19:21:31.743508+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -755,7 +656,7 @@
       "id": "b33fa63f84a4dcd883f5c83a7eda09df3bfbcdb99de4dcacfc1497c964dccc16",
       "url": "https://stroygaz.ru/news/dwelling/v-kurganskoy-oblasti-poyavyatsya-sovremennye-zhilye-kvartaly/",
       "title": "В Курганской области появятся современные жилые кварталы - Строительная газета",
-      "date_published": "2025-09-22T19:21:09.064465+03:00",
+      "date_published": "2025-09-22T19:21:31.125547+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -764,7 +665,7 @@
       "id": "850ed5bd2c1742d4ee511ba065cd7a056e1d864d4717ee369a61881149bf9621",
       "url": "https://stroygaz.ru/news/construction/prezentovan-master-plan-razvitiya-goroda-tary/",
       "title": "Презентован мастер-план развития города Тары - Строительная газета",
-      "date_published": "2025-09-22T19:21:06.750108+03:00",
+      "date_published": "2025-09-22T19:21:29.327972+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -773,16 +674,7 @@
       "id": "cd29291a72e3e125d33d43212d7a5d2f42d96ada87f5626d8cbad2d92f731dd5",
       "url": "https://stroygaz.ru/news/dwelling/v-novostroykakh-lenoblasti-sokratilos-kolichestvo-kvartir-vyshe-20-etazha/",
       "title": "В новостройках Ленобласти сократилось количество квартир выше 20 этажа - Строительная газета",
-      "date_published": "2025-09-22T19:21:06.724658+03:00",
-      "content_text": null,
-      "tags": [],
-      "source": "Стройгаз.ру"
-    },
-    {
-      "id": "369f9ddae5741a5a60a2a45ecb2e9fff4415c7dde7bd575859db43e8fce55cf3",
-      "url": "https://stroygaz.ru/news/hypothec/snizhenie-klyuchevoy-stavki-ozhivilo-spros-na-ipotechnom-rynke/",
-      "title": "Снижение ключевой ставки оживило спрос на ипотечном рынке - Строительная газета",
-      "date_published": "2025-09-22T19:21:04.386154+03:00",
+      "date_published": "2025-09-22T19:21:28.616744+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -791,16 +683,16 @@
       "id": "d9fbb1ade87c27674e97297d69cafafd0beb31fd82b2b937420ab9f80f3268da",
       "url": "https://stroygaz.ru/news/dwelling/ekspert-rasskazal-o-vliyanii-snizheniya-klyuchevoy-stavki-na-rynok-zhilya-v-rossii/",
       "title": "Эксперт рассказал о влиянии снижения ключевой ставки на рынок жилья в России - Строительная газета",
-      "date_published": "2025-09-22T19:21:04.280438+03:00",
+      "date_published": "2025-09-22T19:21:26.877936+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
     },
     {
-      "id": "c5197fe56db3c37291dd59c25acfc2d1ebab97cd51759321ff64273efdf450bb",
-      "url": "https://stroygaz.ru/news/dwelling/kazhdaya-pyataya-elitnaya-kvartira-v-moskve-prodaetsya-v-byvshikh-promzonakh/",
-      "title": "Каждая пятая элитная квартира в Москве продается в бывших промзонах - Строительная газета",
-      "date_published": "2025-09-22T19:21:02.009324+03:00",
+      "id": "369f9ddae5741a5a60a2a45ecb2e9fff4415c7dde7bd575859db43e8fce55cf3",
+      "url": "https://stroygaz.ru/news/hypothec/snizhenie-klyuchevoy-stavki-ozhivilo-spros-na-ipotechnom-rynke/",
+      "title": "Снижение ключевой ставки оживило спрос на ипотечном рынке - Строительная газета",
+      "date_published": "2025-09-22T19:21:26.152927+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -809,7 +701,115 @@
       "id": "9a0beb999856876b7eb8e7fe80132c20cf89cb173e239537d488cf9e26c95d6b",
       "url": "https://stroygaz.ru/news/dwelling/v-tsao-moskvy-zafiksirovana-samaya-bolshaya-dinamika-rosta-tsen-na-novostroyki-/",
       "title": "В ЦАО Москвы зафиксирована самая большая динамика роста цен на новостройки  - Строительная газета",
-      "date_published": "2025-09-22T19:21:01.889291+03:00",
+      "date_published": "2025-09-22T19:21:24.455062+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "c5197fe56db3c37291dd59c25acfc2d1ebab97cd51759321ff64273efdf450bb",
+      "url": "https://stroygaz.ru/news/dwelling/kazhdaya-pyataya-elitnaya-kvartira-v-moskve-prodaetsya-v-byvshikh-promzonakh/",
+      "title": "Каждая пятая элитная квартира в Москве продается в бывших промзонах - Строительная газета",
+      "date_published": "2025-09-22T19:21:23.663233+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "3437a7ad2453ce93246e3dcbef04e37e4b64f66035b8c27a7f4e8c191592bba6",
+      "url": "https://stroygaz.ru/news/architecture/myasnuyu-promyshlennost-na-vdnkh-peredelayut-v-muzey-gradostroitelstva-moskvy-/",
+      "title": "«Мясную промышленность» на ВДНХ переделают в Музей градостроительства Москвы  - Строительная газета",
+      "date_published": "2025-09-22T19:21:22.151077+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "74644760eed2bc71dc1221b068f4025336e29b779f62ec2d13b333c79faabc45",
+      "url": "https://stroygaz.ru/news/kadry/stroitelstvo-stalo-samoy-vysokooplachivaemoy-otraslyu-promyshlennosti-etim-letom/",
+      "title": "Строительство стало самой высокооплачиваемой отраслью промышленности этим летом - Строительная газета",
+      "date_published": "2025-09-22T19:21:21.299511+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "53f109861d43509dce464331f0ec5b4e2bc24f5c91bb01c1fd344d9d13544cb3",
+      "url": "https://stroygaz.ru/news/info-partners-news/vserossiyskiy-forum-praktikum-dlya-developerov-forcities-xi-proydet-etoy-osenyu-v-moskve-/",
+      "title": "Всероссийский форум-практикум для девелоперов FORCITIES XI пройдет этой осенью в Москве  - Строительная газета",
+      "date_published": "2025-09-22T19:21:19.766736+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "7b362dcb782cc3dc68fe95dbe9b80d1a2b605168ac6e3ad82521406a7ddae0c2",
+      "url": "https://stroygaz.ru/news/?VOTE_ID=77&view_result=Y",
+      "title": "Новости - Строительная газета",
+      "date_published": "2025-09-22T19:21:17.340056+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "15f0ee7dc7b4e6c9c6f78c595c7fccfaee0786436d06db8a5bec2391c3d5c8f5",
+      "url": "https://stroygaz.ru/news/",
+      "title": "Новости - Строительная газета",
+      "date_published": "2025-09-22T19:21:14.931629+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "72008417ebaf1f42825d4d1e59127b485b22b08f6cbeecc4f0498ae8982d6266",
+      "url": "https://stroygaz.ru/news/projection/bolee-trekh-tysyach-territoriy-blagoustroili-v-rossii-s-nachala-goda/",
+      "title": "Более трех тысяч территорий благоустроили в России с начала года - Строительная газета",
+      "date_published": "2025-09-22T19:21:12.382590+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "1e0af213e646446f6253a34aa6cceb359da4201c483d01c3f6ba37332050b327",
+      "url": "https://stroygaz.ru/news/projection/v-novomoskovske-za-pyat-let-planiruetsya-sozdat-promyshlenno-gorodskuyu-ekosistemu-na-osnove-printsi/",
+      "title": "В Новомосковске за пять лет планируется создать промышленно-городскую экосистему на основе принципов ESG - Строительная газета",
+      "date_published": "2025-09-22T19:21:10.048886+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "2057a10e15d2a29e89eec28db4c2ae3ca8090f22dffb2fe3ee17b756cbee0761",
+      "url": "https://stroygaz.ru/news/technologies/",
+      "title": "Технологии - Строительная газета",
+      "date_published": "2025-09-22T19:21:07.648610+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "b518803ee2ff5201fd75fae4b2adc635c216f43c082e5908e11bc00d6bb898ed",
+      "url": "https://stroygaz.ru/news/construction/",
+      "title": "Строительство - Строительная газета",
+      "date_published": "2025-09-22T19:21:05.182059+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "4ea5ee7bd014cf78f4101bb907a8bf9fbf12e9baf25c85c62e149b4aa6900921",
+      "url": "https://stroygaz.ru/news/srochno-v-nomer/",
+      "title": "СРОчно в номер - Строительная газета",
+      "date_published": "2025-09-22T19:21:02.834803+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "Стройгаз.ру"
+    },
+    {
+      "id": "161fd4e7710492a8df0565ed2695c8d4f9666f9b7e29c7582e21e5bb5fdaf126",
+      "url": "https://stroygaz.ru/news/samoe-samoe/",
+      "title": "Самое-самое - Строительная газета",
+      "date_published": "2025-09-22T19:21:00.389259+03:00",
       "content_text": null,
       "tags": [],
       "source": "Стройгаз.ру"
@@ -1778,6 +1778,24 @@
       "source": "Правительство РФ"
     },
     {
+      "id": "c43d358b3bac6a7b19d72877fed5589ca70087059fc6137312512d64d9394d45",
+      "url": "https://faufcc.ru/press-tsentr/novosti/fond-nti-vydelit-5-mlrd-rublei-na-razvitie-tekhnologii-bas",
+      "title": "Фонд НТИ выделит 5 млрд рублей на развитие технологий БАС",
+      "date_published": "2025-09-19T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "d06727395479356ee1a1b551d87b8684c6d1ffeed9a7f8ee0399c17b42fad043",
+      "url": "https://faufcc.ru/press-tsentr/novosti/kliuchevye-napravleniia-razvitiia-normativnoi-bazy-transportnogo-stroitelstva-obsudili-s-uchastiem-fau-ftss",
+      "title": "Ключевые направления развития нормативной базы транспортного строительства обсудили с участием ФАУ «ФЦС»",
+      "date_published": "2025-09-19T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
       "id": "2367c9de3f59c9148fbf50624689715a7e92adb28e5027977a0532858a16eb64",
       "url": "https://ardexpert.ru/article/28325",
       "title": "5 российских производителей светильников из натуральных материалов",
@@ -1785,6 +1803,15 @@
       "content_text": null,
       "tags": [],
       "source": "АРД: статьи"
+    },
+    {
+      "id": "9217a1a3f0707d20545cda0021b8c5f18deaeae75bb51b6b59600011c17d6bdb",
+      "url": "https://faufcc.ru/press-tsentr/novosti/direktor-fau-ftss-andrei-kopytin-prinial-uchastie-v-otkrytii-proekta-ekspertiza-budushchego",
+      "title": "Директор ФАУ «ФЦС» Андрей Копытин принял участие в открытии проекта «Экспертиза будущего»",
+      "date_published": "2025-09-18T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
     },
     {
       "id": "9f87be2503eab1b4d278e71c8da3fdd67b3db70f6852c6db77409a15a97b3c3b",
@@ -1832,6 +1859,24 @@
       "source": "АРД: статьи"
     },
     {
+      "id": "c2ec781516aa9a25849ac8c75e0bb67e8ee7ee4267a8c126a2b46c56088d2bbf",
+      "url": "https://faufcc.ru/press-tsentr/novosti/fau-ftss-uchastvuet-v-delovoi-programme-mezhdunarodnogo-simpoziuma-mgsu",
+      "title": "ФАУ «ФЦС» участвует в деловой программе международного симпозиума МГСУ",
+      "date_published": "2025-09-17T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "cf53b300406d806047e29e62065bd57d20c2e8d3f14bb4880498b63327a21af0",
+      "url": "https://faufcc.ru/press-tsentr/novosti/v-minstroe-rossii-obsudili-rasshirenie-zadach-tk-465-stroitelstvo",
+      "title": "В Минстрое России обсудили расширение задач ТК 465 \"Строительство\"",
+      "date_published": "2025-09-17T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
       "id": "8f78e1741fb4587721683ce925b648693fdedb9c3d844b9dbede7d58a799f709",
       "url": "https://ardexpert.ru/article/28318",
       "title": "Богоявленский собор Авраамиева монастыря в Ростове Великом",
@@ -1839,6 +1884,15 @@
       "content_text": null,
       "tags": [],
       "source": "АРД: статьи"
+    },
+    {
+      "id": "8715f5b40a6b488d1d29862efd3fa4134fb16a155becdfca6fee613aed18dfda",
+      "url": "https://faufcc.ru/press-tsentr/novosti/minstroi-rossii-organizuet-provedenie-nauchnykh-issledovanii-dlia-innovatsionnogo-razvitiia-otrasli",
+      "title": "Минстрой России организует проведение научных исследований для инновационного развития отрасли",
+      "date_published": "2025-09-16T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
     },
     {
       "id": "f62d0b42f2b71001be45989cf2bf8daae7a97f27c745c5b53dc8840f706c7b05",
@@ -1857,6 +1911,15 @@
       "content_text": null,
       "tags": [],
       "source": "АРД: статьи"
+    },
+    {
+      "id": "9bdfef83e59f2bcadc83336db9a858b4f35dd872f2eeb74125841b04658117eb",
+      "url": "https://faufcc.ru/press-tsentr/novosti/fau-ftss-pozdravliaet-rosstandart-s-iubileem",
+      "title": "ФАУ «ФЦС» поздравляет Росстандарт с Юбилеем!",
+      "date_published": "2025-09-15T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
     },
     {
       "id": "7f132b94ec56b7fb0d63aaceecd5ad7ec3b1203ac5ac086135f594e747bb40b2",
@@ -1913,10 +1976,397 @@
       "source": "АРД: статьи"
     },
     {
+      "id": "3bda7abb9dc2891d1a271912e5f90ab37455c0b6d7b1a7472c1b0a08bf36a984",
+      "url": "https://faufcc.ru/press-tsentr/novosti/fau-ftss-provedeno-planovoe-obnovlenie-klassifikatora-stroitelnoi-informatsii",
+      "title": "ФАУ «ФЦС» проведено плановое обновление Классификатора строительной информации",
+      "date_published": "2025-09-12T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "6a976461daf41bc9d6e6c48805903b787354ac7a20750c0189632d0acf908e48",
+      "url": "https://faufcc.ru/press-tsentr/novosti/rezultaty-i-perspektivy-vzaimodeistviia-tk-357-i-tk-465-obsudili-v-volzhskom",
+      "title": "Результаты и перспективы взаимодействия ТК 357 и ТК 465 обсудили в Волжском",
+      "date_published": "2025-09-11T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "108cbc449f858db0e4f1352f04257ef629dd68b10eaa169b02e4279a5d52c510",
+      "url": "https://faufcc.ru/press-tsentr/novosti/dmitrii-grigorenko-pravitelstvo-vnedrilo-iskusstvennyi-intellekt-v-sistemu-upravleniia-natsproektami",
+      "title": "Дмитрий Григоренко: Правительство внедрило искусственный интеллект в систему управления нацпроектами",
+      "date_published": "2025-09-11T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "843c827b2d1598f27b53c0f6fe46612c807891f78c447aab60ba00915edd14c0",
+      "url": "https://faufcc.ru/press-tsentr/novosti/novye-redaktsii-dvukh-znakovykh-svodov-pravil-razmeshcheny-dlia-publichnogo-obsuzhdeniia",
+      "title": "Новые редакции двух знаковых сводов правил размещены для публичного обсуждения",
+      "date_published": "2025-09-10T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "780571651d1a9df6e8d60afe8dd07ca00eb193bbd19225c947b1527c8cb54b43",
+      "url": "https://faufcc.ru/press-tsentr/novosti/utverzhden-kompleksnyi-plan-razvitiia-infrastruktury-do-2036-goda",
+      "title": "Утвержден комплексный план развития инфраструктуры до 2036 года",
+      "date_published": "2025-09-09T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "697e2c84531d8b71fa38a1bfef32ab94f70c844b84de96f9d049eef05c50a95c",
+      "url": "https://faufcc.ru/press-tsentr/novosti/3d-pechat-v-stroitelstve-ot-eksperimenta-k-massovomu-vnedreniiu",
+      "title": "3d-печать в строительстве: от эксперимента к массовому внедрению",
+      "date_published": "2025-09-04T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "a831520dc7bfd79efeda8591c8ae3a4e3ebdaa4389e2c5308a20ed73d825a641",
+      "url": "https://faufcc.ru/press-tsentr/novosti/ko-dniu-znanii-obnovleno-svyshe-800-km-dorog-vedushchikh-k-obrazovatelnym-uchrezhdeniiam",
+      "title": "Ко Дню знаний обновлено свыше 800 км дорог, ведущих к образовательным учреждениям",
+      "date_published": "2025-09-02T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "189665ab8ed0e17d34c28d24f0bd35c39fcd7f55bb94156bc26319c6b1e6c3d6",
+      "url": "https://faufcc.ru/press-tsentr/novosti/razvitie-normativnoi-bazy-dlia-mostostroeniia-obsudili-v-novotroitske",
+      "title": "Развитие нормативной базы для мостостроения обсудили в Новотроицке",
+      "date_published": "2025-09-01T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "3b0b4a0bffba5148e5d0f840a512050ce71b8637fe8034e52a21252f74637574",
+      "url": "https://faufcc.ru/press-tsentr/novosti/rosel-sozdal-lineiku-miniatiurnykh-rezonatorov-dlia-oborudovaniia-sviazi",
+      "title": "\"Росэл\" создал линейку миниатюрных резонаторов для оборудования связи",
+      "date_published": "2025-09-01T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "4dbfbe10f6e7c83d113f68c3e991000f27b1070aa3cf4df6a5bf019c8e877c50",
+      "url": "https://faufcc.ru/press-tsentr/novosti/fau-ftss-podtverzhdena-prigodnost-primeneniia-zashchitnykh-ograzhdenii-dlia-gonochnykh-trass",
+      "title": "ФАУ «ФЦС» подтверждена пригодность применения защитных ограждений для гоночных трасс",
+      "date_published": "2025-08-28T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "a8d179f706f5f368277cbcdea38b98ef8708c667143ac4f485f567bcc2f8efb6",
+      "url": "https://faufcc.ru/press-tsentr/novosti/v-pekine-otkryli-iarmarku-rossiiskikh-tovarov",
+      "title": "В Пекине открыли ярмарку российских товаров",
+      "date_published": "2025-08-28T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "0aafde93c9b6b89a56a0566d410c9f4093d26763f4f1fd991a018614ec1afd44",
+      "url": "https://faufcc.ru/press-tsentr/novosti/minstroi-rossii-vnedriaet-novye-standarty-remonta-podzemnoi-transportnoi-infrastruktury",
+      "title": "Минстрой России внедряет новые стандарты ремонта подземной транспортной инфраструктуры",
+      "date_published": "2025-08-28T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "2b4351f175473fbfc7fe77c30a4b74289b90f795b61aab0f3626b394842058d5",
+      "url": "https://faufcc.ru/press-tsentr/novosti/razvitie-rossiiskogo-rynka-stroitelnykh-materialov-obsudili-eksperty-na-vystavke-china-machinery-fair",
+      "title": "Развитие  российского рынка строительных материалов обсудили эксперты на выставке China Machinery Fair",
+      "date_published": "2025-08-28T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "498fead98751c40998958246fa417c0c11771659dd58c9e2cf7fcac2829ce81f",
+      "url": "https://faufcc.ru/press-tsentr/novosti/minstroi-rossii-aktualiziroval-bazovyi-svod-pravil-po-ekspluatatsii-tsentralizovannykh-sistem-vodosnabzheniia-i-vodootvedeniia",
+      "title": "Минстрой России актуализировал базовый свод правил по эксплуатации централизованных систем водоснабжения и водоотведения",
+      "date_published": "2025-08-27T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "a82e13c709b041eb83fe0a5a3b3d486e017f163220f844cd90b197f8fbf51674",
+      "url": "https://faufcc.ru/press-tsentr/novosti/eshche-13-svodov-pravil-razmeshcheny-dlia-publichnogo-obsuzhdeniia",
+      "title": "Еще 13 сводов правил размещены для публичного обсуждения",
+      "date_published": "2025-08-27T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "aa7d8c6f6d5c8d2924cc474eb7480179babcd95e6d2c8c292d701e516ee6e30a",
+      "url": "https://faufcc.ru/press-tsentr/novosti/s-nachala-goda-bolee-15-tys-km-federalnykh-dorog-vvedeny-v-ekspluatatsiiu-blagodaria-natsproektu",
+      "title": "С начала года более 1,5 тыс. км федеральных дорог введены в эксплуатацию благодаря нацпроекту",
+      "date_published": "2025-08-26T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "fcd99a547a771b1c0585456bc6c179acdf02bf44d71e83b5d57904284c791bba",
+      "url": "https://faufcc.ru/press-tsentr/novosti/minstroi-rossiiskii-standart-po-informatsionnomu-modelirovaniiu-vvedut-v-uzbekistane",
+      "title": "Минстрой: российский стандарт по информационному моделированию введут в Узбекистане",
+      "date_published": "2025-08-25T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "609e88f88e8fc56f7a3f74717207ac63f4c6c2df45ba4ccad3873db46c93a622",
+      "url": "https://faufcc.ru/press-tsentr/novosti/utverzhdion-novyi-standart-dlia-zhelezobetonnykh-plity-perekrytii-dlia-zhilykh-zdanii",
+      "title": "Утверждён новый стандарт для железобетонных плиты перекрытий для жилых зданий",
+      "date_published": "2025-08-25T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "36b7bf8815e8db76fc794a42bc5f789d64ac81d742e827552a953dbf1090b0db",
+      "url": "https://faufcc.ru/press-tsentr/novosti/minimizatsiiu-riskov-postupleniia-falsifikata-na-stroirynok-obsudili-s-uchastiem-fau-ftss",
+      "title": "Минимизацию рисков поступления фальсификата на стройрынок обсудили с участием ФАУ «ФЦС»",
+      "date_published": "2025-08-22T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "1a4cbc90069d65e3bb0e7f04c7435f4d9fc879aea192a5cf4a98360134d83b84",
+      "url": "https://faufcc.ru/press-tsentr/novosti/22-avgusta-my-otmechaem-den-gosudarstvennogo-flaga-rossiiskoi-federatsii",
+      "title": "22 августа мы отмечаем День Государственного флага Российской Федерации!",
+      "date_published": "2025-08-22T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "88d4e7472dd209b925ce7139197ecfb7086d4469cfa28e8b315612f6618bd8f3",
+      "url": "https://faufcc.ru/press-tsentr/novosti/v-avguste-prokhodiat-publichnye-obsuzhdeniia-sem-svodov-pravil",
+      "title": "В августе проходят публичные обсуждения семь сводов правил",
+      "date_published": "2025-08-21T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "b3e77ebbe6a3b75d3e0a4dc94d46381d0296988d0d3198048cda9fe8e28fbc41",
+      "url": "https://faufcc.ru/press-tsentr/novosti/v-rossii-zavershili-bolee-720-obektov-i-meropriiatii-blagodaria-biudzhetnym-kreditam",
+      "title": "В России завершили более 720 объектов и мероприятий благодаря бюджетным кредитам",
+      "date_published": "2025-08-21T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "8c180ab69507fff8140f02ca2aee9bb49e6f10beb1b084659269c9664b930220",
+      "url": "https://faufcc.ru/press-tsentr/novosti/na-konferentsii-baltimikh-2025-obsudili-zadachi-innovatsionnogo-razvitiia-stroitelnoi-otrasli",
+      "title": "На конференции BALTIMIХ-2025 обсудили задачи инновационного развития строительной отрасли",
+      "date_published": "2025-08-19T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "0aa80cde9fb7c0fa585b694810f1da63446bf03032a5768507bfa9add76ce7c3",
+      "url": "https://faufcc.ru/press-tsentr/novosti/v-minstroe-rossii-sostoialos-torzhestvennoe-vruchenie-vedomstvennykh-nagrad",
+      "title": "В Минстрое России состоялось торжественное вручение ведомственных наград",
+      "date_published": "2025-08-18T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "889086ba58f8c31ace32de05d0f7c02b65535feda7718634c033f9f0bde10bbe",
+      "url": "https://faufcc.ru/press-tsentr/novosti/mer-summa-raspredeliaemykh-infrastrukturnykh-kreditov-vyrastet-do-126-mlrd-rublei",
+      "title": "МЭР: сумма распределяемых инфраструктурных кредитов вырастет до 126 млрд рублей",
+      "date_published": "2025-08-18T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "9a332e5196624c000d8159863859f66e0782280600ee08feb2bb19a3f6c8b191",
+      "url": "https://faufcc.ru/press-tsentr/novosti/razvitie-normativnoi-bazy-dlia-primeneniia-bas-v-stroitelstve-idet-proaktivno",
+      "title": "Развитие нормативной базы для применения БАС в строительстве идет проактивно",
+      "date_published": "2025-08-18T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "0c53b378be1873a754ec3760a1962a113720578a852eab3ce43736c48924b551",
+      "url": "https://faufcc.ru/press-tsentr/novosti/delegatsiia-fau-ftss-posetila-zavod-odnogo-iz-krupneishikh-proizvoditelei-polimernykh-trub-v-sng",
+      "title": "Делегация ФАУ «ФЦС» посетила завод одного из крупнейших производителей полимерных труб в СНГ",
+      "date_published": "2025-08-14T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "9fa851955f47b60074c55a7d17e6dbe8d60ac37c41a78294d1cb017838ac94db",
+      "url": "https://faufcc.ru/press-tsentr/novosti/dlia-razvitiia-normativnoi-bazy-stroitelnoi-otrasli-s-nachala-2025-goda-vstupili-v-deistvie-50-svodov-pravil-i-68-gostov",
+      "title": "Для развития нормативной базы строительной отрасли с начала 2025 года вступили в действие 50 сводов правил и 68 ГОСТов",
+      "date_published": "2025-08-12T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "afad8966b5c453b7de2e84da8d4e3795fc4efc21c018a3cdb8ead943e9b7e4ab",
+      "url": "https://faufcc.ru/press-tsentr/novosti/s-dnem-stroitelia",
+      "title": "С Днем Строителя!",
+      "date_published": "2025-08-10T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "f1b265c55bdc83a4ce516be456701fc7864b68e58d2ca8d6fe8555e6069d84c1",
+      "url": "https://faufcc.ru/press-tsentr/novosti/11-nagrad-minstroia-rossii-poluchili-sotrudniki-fau-ftss",
+      "title": "11 наград Минстроя России получили сотрудники ФАУ «ФЦС»",
+      "date_published": "2025-08-08T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "a5ac592106a69026941366229676b1a0d595abb85df8db932d3b05b1bdd88ec2",
+      "url": "https://faufcc.ru/press-tsentr/novosti/komanda-minstroia-rossii-pobedila-v-druzheskom-turnire-po-shakhmatam",
+      "title": "Команда Минстроя России победила в дружеском турнире по шахматам",
+      "date_published": "2025-08-07T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "04ef8133b1d85fc3509a6275d3eb96de088c8e3f31bcb32522f204685c5e2c7b",
+      "url": "https://faufcc.ru/press-tsentr/novosti/ushel-iz-zhizni-iurii-vladimirovich-novak",
+      "title": "Ушел из жизни Юрий Владимирович Новак",
+      "date_published": "2025-08-06T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "71bfd1789c21508d5ed6a6ea5f94fc9a1b4e179b1fffb4fc2b93e6891a76f863",
+      "url": "https://faufcc.ru/press-tsentr/novosti/standartizatsiia-v-stroitelstve-fundament-rosta-i-tekhnologicheskoi-nezavisimosti",
+      "title": "Стандартизация в строительстве – фундамент роста и технологической независимости",
+      "date_published": "2025-08-06T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "ce433e78013037810797c7ac6294a92b5b7c551482cfbf374e3980cfc2a94588",
+      "url": "https://faufcc.ru/press-tsentr/novosti/marat-khusnullin-poriadka-12-tys-obektov-i-meropriiatii-nakhodiatsia-v-rabote-po-reestru-obektov-kapitalnogo-stroitelstva",
+      "title": "Марат Хуснуллин: Порядка 1,2 тыс. объектов и мероприятий находятся в работе по реестру объектов капитального строительства",
+      "date_published": "2025-08-06T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "10e9325002fb6d6fca1e91bae68b6cf7170a3740504a037c4d407099a2c47fba",
+      "url": "https://faufcc.ru/press-tsentr/novosti/blagodaria-natsproektu-v-etom-godu-obnoviat-poriadka-700-km-dorog-k-sportivnym-uchrezhdeniiam",
+      "title": "Благодаря нацпроекту в этом году обновят порядка 700 км дорог к спортивным учреждениям",
+      "date_published": "2025-08-05T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "7d4dd06de475563edff41b18da8a5226da315ffdfc519403d0fbfbe25d0c03ff",
+      "url": "https://faufcc.ru/press-tsentr/novosti/pravitelstvo-rossii-razvivaet-infrastrukturu-dlia-elektromobilei",
+      "title": "Правительство России развивает инфраструктуру для электромобилей",
+      "date_published": "2025-07-29T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "e38e50ca40178155eb2aea113da7f3fa628b4d1e7ab4585c3503bbfb0fb73daa",
+      "url": "https://faufcc.ru/press-tsentr/novosti/spetsialisty-fau-ftss-priniali-uchastie-v-iv-vserossiiskom-sezde-spetsialistov-press-sluzhb-v-sfere-stroitelstva-i-zhilishchno-kommunalnogo-khoziaistva",
+      "title": "Специалисты ФАУ «ФЦС» приняли участие в  IV Всероссийском съезде специалистов пресс-служб в сфере строительства и жилищно-коммунального хозяйства",
+      "date_published": "2025-07-28T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "a79009cf83c302a67ffb35d56db5e1e8ba11935a03b0e859dde02fa3cb297c2d",
+      "url": "https://faufcc.ru/press-tsentr/novosti/minstroi-rossii-rasshiriaet-vozmozhnosti-primeneniia-trubchatykh-svetovodov-estestvennogo-sveta",
+      "title": "Минстрой России расширяет возможности применения трубчатых световодов естественного света",
+      "date_published": "2025-07-25T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "e24f8b87a314c496a2e8e326615b6d061f519b10be7fb835a012801ef87a5919",
+      "url": "https://faufcc.ru/press-tsentr/novosti/privetstvennoe-slovo-ministra-stroitelstva-i-zhilishchno-kommunalnogo-khoziaistva-rossiiskoi-federatsii-ireka-faizullina-k-uchastnikam-iv-vserossiiskogo-sezda-press-sekretarei-v-stroiotrasli-i-zhkkh",
+      "title": "Приветственное слово Министра строительства и жилищно-коммунального хозяйства Российской Федерации Ирека Файзуллина к участникам IV Всероссийского съезда пресс-секретарей в стройотрасли и ЖКХ",
+      "date_published": "2025-07-25T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "91fcd60a5f1ce6ee6b555ac29a8cd37ea9fca3d1872fc5b46a15aef944fbc34d",
+      "url": "https://faufcc.ru/press-tsentr/novosti/fau-ftss-podgotovleny-pervye-redaktsii-svodov-pravil-dlia-publichnogo-obsuzhdeniia",
+      "title": "ФАУ \"ФЦС\" подготовлены первые редакции сводов правил для публичного обсуждения",
+      "date_published": "2025-07-24T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "726c9e030ef512359fd4829b44bcf0b03bfc84ef806bf37654d5309109a8865b",
+      "url": "https://faufcc.ru/press-tsentr/novosti/marat-khusnullin-bolee-500-km-dorog-vveli-v-ekspluatatsiiu-blagodaria-biudzhetnym-kreditam",
+      "title": "Марат Хуснуллин: Более 500 км дорог ввели в эксплуатацию благодаря бюджетным кредитам",
+      "date_published": "2025-07-24T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "754e4fce1c46100fed8eec43827703ff8c6bb0ccda6a991ae7a4f9f9417f6b07",
+      "url": "https://faufcc.ru/press-tsentr/novosti/k-2030-godu-zaplanirovana-masshtabnaia-modernizatsiia-aerodromnoi-seti",
+      "title": "К 2030 году запланирована масштабная модернизация аэродромной сети",
+      "date_published": "2025-07-23T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
+      "id": "9f54361ee13b3d2fbb1511514c58fa2150ff775a0f8b0cab10fa189436d8faf9",
+      "url": "https://faufcc.ru/press-tsentr/novosti/v-rossii-za-polgoda-blagoustroili-pochti-600-territorii",
+      "title": "В России за полгода благоустроили почти 600 территорий",
+      "date_published": "2025-07-23T00:00:00+03:00",
+      "content_text": null,
+      "tags": [],
+      "source": "ФАУ ФЦС"
+    },
+    {
       "id": "2f601b387561351d552dced47d6f0e6153afb7577a845396b4791b5a5d7603b0",
       "url": "https://www.metalinfo.ru/ru/news/176776",
       "title": "Росгеология начала полевые работы II этапа «Геология: возрождение легенды»",
-      "date_published": "2025-01-01T17:23:00.062268+03:00",
+      "date_published": "2025-01-01T17:23:47.969647+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1925,7 +2375,7 @@
       "id": "8fbda8c96b10e48dbb75e8af1f0f15527adb8b74144293bfacfdf7548a1be0ea",
       "url": "https://www.metalinfo.ru/ru/news/176752",
       "title": "Центр оценки квалификаций ВИЗ-Стали продолжает расширять полномочия",
-      "date_published": "2025-01-01T16:16:06.967128+03:00",
+      "date_published": "2025-01-01T16:16:54.814544+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1934,7 +2384,7 @@
       "id": "bb7d9847ac721f716831a99c74c6c90ff71f4c7ed2e2892359ac285cd5f73708",
       "url": "https://www.metalinfo.ru/ru/news/176723",
       "title": "В МФТИ разработали IT-систему, повышающую долговечность мельниц для измельчения руды",
-      "date_published": "2025-01-01T16:07:36.259327+03:00",
+      "date_published": "2025-01-01T16:07:23.968017+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1943,7 +2393,7 @@
       "id": "200993fa90fc2157aab06597234f01ec410cad3eacc2edeb8eaf2aece892960d",
       "url": "https://www.metalinfo.ru/ru/news/176756",
       "title": "Проект по производству судового оборудования из Дубны получит поддержку на 0,5 млрд рублей",
-      "date_published": "2025-01-01T14:38:33.948265+03:00",
+      "date_published": "2025-01-01T14:38:21.875279+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1952,7 +2402,7 @@
       "id": "0c4c1f382276d8e98a17916df4fb1e7031877f8faf89b6fd573866498790d4c5",
       "url": "https://www.metalinfo.ru/ru/news/176771",
       "title": "Как ведут себя цены на серебро, золото и медь",
-      "date_published": "2025-01-01T12:27:20.253800+03:00",
+      "date_published": "2025-01-01T12:27:08.118880+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1961,7 +2411,7 @@
       "id": "721864255dd36481769eac5ca8913c63aa6237cb872c149402b8e7c352d5d42f",
       "url": "https://www.metalinfo.ru/ru/news/176769",
       "title": "Северсталь запустила платформу генеративного искусственного интеллекта",
-      "date_published": "2025-01-01T12:23:33.328690+03:00",
+      "date_published": "2025-01-01T12:23:21.041377+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1970,7 +2420,7 @@
       "id": "cbd35af55a83c66955de509af2748612e8995acd5d9f6efd769a50391540cbc3",
       "url": "https://www.metalinfo.ru/ru/news/176735",
       "title": "KAZ Minerals сократила производство меди в первом полугодии на 4%",
-      "date_published": "2025-01-01T07:49:22.346856+03:00",
+      "date_published": "2025-01-01T07:49:10.202947+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1979,7 +2429,7 @@
       "id": "531918113642d5e52437431e0fe0d31c2662042ec551f6d6f710a248bdad2f4d",
       "url": "https://www.metalinfo.ru/ru/news/176754",
       "title": "Алюминиевая отрасль РФ готова внести вклад в развитие городской инфраструктуры Филиппин",
-      "date_published": "2025-01-01T07:40:08.780133+03:00",
+      "date_published": "2025-01-01T07:40:56.651442+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1988,7 +2438,7 @@
       "id": "a2e1b48e1414d2fe8b1a6dbd04f5f623aed1828db0c6c3d312e4c140f1b439dc",
       "url": "https://www.metalinfo.ru/ru/news/176763",
       "title": "Трубная промышленность: кризис спроса и технологические прорывы",
-      "date_published": "2025-01-01T07:10:01.881721+03:00",
+      "date_published": "2025-01-01T07:10:49.716836+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"
@@ -1997,7 +2447,7 @@
       "id": "cea521ffd7de0a3ec6151812c21a280614ca61f604a9764c49be1698bbd9f228",
       "url": "https://www.metalinfo.ru/ru/news/176761",
       "title": "Когда падать дальше некуда",
-      "date_published": "2025-01-01T07:02:28.866442+03:00",
+      "date_published": "2025-01-01T07:02:16.772431+03:00",
       "content_text": null,
       "tags": [],
       "source": "Металлоснабжение и сбыт"

--- a/sources.json
+++ b/sources.json
@@ -44,6 +44,8 @@
     "name": "ФАУ ФЦС",
     "base_url": "https://faufcc.ru",
     "start_url": "https://faufcc.ru/press-tsentr/novosti",
+    "mode": "api",
+    "api_endpoint": "https://api.faufcc.ru/api/publications?type=news&page=1&limit=50",
     "include_patterns": [
       "/press-tsentr/novosti",
       "/press-center/news"


### PR DESCRIPTION
## Summary
- add an API-specific harvester that fetches JSON payloads, respects throttling, and still normalizes items through `build_item`
- configure the FAU ФЦС source to use the discovered publications endpoint
- rebuild the unified feed so the new materials appear with Moscow timestamps

## Testing
- python scripts/aggregate.py --rebuild

------
https://chatgpt.com/codex/tasks/task_e_68d1cdbfcf2c832c81d116b5c7fbff24