### PR TITLE
Improve date parsing and crawler resilience

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -13,7 +13,7 @@
   {
     "name": "Минстрой России",
     "base_url": "https://minstroyrf.gov.ru",
-    "start_url": "https://minstroyrf.gov.ru/press/?d=news?per-page=24",
+    "start_url": "https://minstroyrf.gov.ru/press/?d=news&per-page=24",
     "include_patterns": [
       "/press/"
     ],
@@ -74,7 +74,14 @@
     "include_patterns": [
       "/news/"
     ],
-    "link_min_text_len": 8
+    "include_regex": "^https?://(?:www\\.)?eec\\.eaeunion\\.org/news/(?!events/?$)[^?#]+/?$",
+    "exclude_regex": [
+      "^https?://(?:www\\.)?eec\\.eaeunion\\.org/news/?$",
+      "^https?://(?:www\\.)?eec\\.eaeunion\\.org/news/events/?$",
+      "^https?://(?:www\\.)?eec\\.eaeunion\\.org/news/(?:page|tag|category|archive|search)/"
+    ],
+    "link_min_text_len": 8,
+    "restrict_domain": true
   },
   {
     "name": "Минфин России",


### PR DESCRIPTION
## Summary
- include query hashes in cache keys and reuse cached HTML when article requests return 5xx errors
- broaden common date selectors so sources with custom markup expose publication dates
- refine source configuration for EEC and correct the Minstroy start URL to avoid navigation pages overwriting content

## Testing
- python -m compileall scripts/aggregate.py

------
https://chatgpt.com/codex/tasks/task_e_68d20601b590832cbf2987bcbdea7996