### PR TITLE
Preserve real publish date when fallback timestamp appears

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -916,6 +916,19 @@ def merge_items(existing, new):
 
         merged = dict(old)
         for key, value in it.items():
+            if key == "date_published":
+                old_date = old.get("date_published")
+                new_date = value
+                if old_date and new_date:
+                    item_id = it.get("id") or old.get("id")
+                    if item_id:
+                        first_seen_map = STATE.get("first_seen", {})
+                        fallback_date = first_seen_map.get(item_id)
+                        if fallback_date and fallback_date == new_date:
+                            # The new value comes from the first-seen fallback; keep the
+                            # previously stored publication date instead of overwriting it
+                            # with the crawl timestamp.
+                            continue
             if key in rich_fields and not has_rich_value(value):
                 continue
             merged[key] = value

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,10 +1,23 @@
+import pathlib
+import sys
 import unittest
 
 
-from scripts.aggregate import merge_items
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+from scripts.aggregate import merge_items, STATE
 
 
 class MergeItemsTests(unittest.TestCase):
+    def setUp(self):
+        # Preserve the original first_seen map so tests can safely modify it.
+        self._orig_first_seen = dict(STATE.get("first_seen", {}))
+
+    def tearDown(self):
+        STATE.setdefault("first_seen", {}).clear()
+        STATE["first_seen"].update(self._orig_first_seen)
+
     def test_keeps_existing_content_text_when_new_is_missing(self):
         existing = [
             {
@@ -30,6 +43,35 @@ class MergeItemsTests(unittest.TestCase):
         self.assertEqual(item["title"], "Updated title")
         self.assertEqual(item["date_published"], "2024-09-23T10:00:00+03:00")
         self.assertEqual(item["content_text"], "Existing full text")
+
+    def test_retains_original_date_when_new_uses_first_seen_fallback(self):
+        item_id = "news-1"
+        fallback_iso = "2024-09-25T12:00:00+03:00"
+        STATE.setdefault("first_seen", {})[item_id] = fallback_iso
+
+        existing = [
+            {
+                "id": item_id,
+                "url": "https://example.com/news/1",
+                "title": "First crawl",
+                "date_published": "2024-09-20T09:00:00+03:00",
+            }
+        ]
+        new = [
+            {
+                "id": item_id,
+                "url": "https://example.com/news/1",
+                "title": "Second crawl",
+                "date_published": fallback_iso,
+            }
+        ]
+
+        merged = merge_items(existing, new)
+
+        self.assertEqual(len(merged), 1)
+        item = merged[0]
+        self.assertEqual(item["date_published"], "2024-09-20T09:00:00+03:00")
+        self.assertEqual(item["title"], "Second crawl")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prevent merge logic from overwriting an existing publication date with the first-seen fallback timestamp
- add regression coverage for the scenario where a later crawl loses the real date but should keep the stored value

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3058357d0832c94ca5cdde15bc0f3