### PR TITLE
Add listing filters and improve JSON content extraction

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -132,6 +132,12 @@
     ],
     "include_regex": "/ru/news/\\d+(?:/|\\.html)?$",
     "exclude_regex": "/ru/news/(?:r\\w+|services|subscribe|market|consumer|construction|nonferrous|ferrous)",
+    "content_selectors": [
+      ".newsText",
+      ".news-detail",
+      "[itemprop='articleBody']",
+      "article"
+    ],
     "link_min_text_len": 8,
     "max_links": 20,
     "restrict_domain": true,
@@ -200,6 +206,9 @@
       "/news/"
     ],
     "link_min_text_len": 8,
+    "exclude_regex": [
+      "^https?://(?:www\\.)?ria-stk\\.ru/news/?$"
+    ],
     "enabled": true,
     "request_strategy": {
       "connect_timeout": 5,
@@ -222,6 +231,9 @@
     "include_patterns": [
       "/news/"
     ],
+    "exclude_regex": [
+      "\\?page=\\d+$"
+    ],
     "link_min_text_len": 8,
     "enabled": true
   },
@@ -232,8 +244,13 @@
     "include_regex": "^https?://(?:www\\.)?stroygaz\\.ru/news/[a-z0-9-]+/[a-z0-9-]+/(?:[a-z0-9-]+/)*$",
     "exclude_regex": [
       "\\?",
-      "/news/?$",
-      "/news/[a-z0-9-]+/?$"
+      "/news/?$"
+    ],
+    "content_selectors": [
+      ".content",
+      ".news-detail",
+      ".article",
+      ".news-text"
     ],
     "link_min_text_len": 8,
     "enabled": true
@@ -245,6 +262,11 @@
     "include_patterns": [
       "/20"
     ],
+    "content_selectors": [
+      "[itemprop='articleBody']",
+      ".article__content",
+      "article"
+    ],
     "link_min_text_len": 8,
     "enabled": true
   },
@@ -254,6 +276,13 @@
     "start_url": "https://rg.ru/tema/ekonomika",
     "include_patterns": [
       "/20"
+    ],
+    "content_selectors": [
+      "article .article__body",
+      ".article__text",
+      ".b-material-body__content",
+      "[itemprop='articleBody']",
+      "main article"
     ],
     "link_min_text_len": 8,
     "enabled": true


### PR DESCRIPTION
## Summary
- added a reusable listing/service URL filter that skips queueing links with trailing `/news/`, pagination segments, or page/vote query parameters before they enter the crawl pipeline
- taught JSON-mode harvesters to reuse API-supplied article bodies before falling back to HTML scraping, and shared item construction helpers between API and HTML paths
- refreshed content selectors and exclusion rules for metalinfo.ru, stroygaz.ru, rg.ru, realty.ria.ru, ria-stk.ru, and government.ru to extract full article text

## Testing
- `python scripts/aggregate.py --rebuild` *(прервано: локальный прогон затянулся из-за длительных сетевых ответов; потребуется повторить на CI)*

## Notes
- листинговый фильтр на отладочном запуске отбрасывал, например: https://notim.ru/news/, https://www.gostinfo.ru/News/List?page=2, http://ancb.ru/publication/page/2, https://eec.eaeunion.org/news/, https://www.metalinfo.ru/ru/news/archive (см. вывод `--debug`)
- карточки API источников (ФАУ ФЦС и др.) теперь заполняют `content_text` из HTML даже при отсутствии текстового поля в JSON; необходимо подтвердить метрики после полной пересборки

------
https://chatgpt.com/codex/tasks/task_e_68d4837f2adc832c9116544c779a1b72