### PR TITLE
Improve listing detection and content harvesting

### DIFF
--- a/scripts/url_filters.py
+++ b/scripts/url_filters.py
@@ -6,6 +6,16 @@ import re
 from urllib.parse import parse_qsl, urlparse
 
 _LISTING_SEGMENTS = {"tag", "category", "archive", "search", "page"}
+_SECTION_PREFIXES = {
+    "news",
+    "novosti",
+    "lenta",
+    "tema",
+    "topics",
+    "press",
+    "press-center",
+    "press-tsentr",
+}
 
 
 def _path_segments(path: str) -> list[str]:
@@ -25,6 +35,12 @@ def is_listing_url(url: str | None) -> bool:
     if segments:
         last_segment = segments[-1]
         if last_segment == "news":
+            return True
+        if (
+            len(segments) == 2
+            and segments[0] in _SECTION_PREFIXES
+            and not segments[1].isdigit()
+        ):
             return True
     if any(segment in _LISTING_SEGMENTS for segment in segments):
         return True

--- a/sources.json
+++ b/sources.json
@@ -247,6 +247,7 @@
       "/news/?$"
     ],
     "link_min_text_len": 8,
+    "min_words": 100,
     "enabled": true,
     "content_selectors": [
       ".content",

--- a/tests/test_amp_whitelist.py
+++ b/tests/test_amp_whitelist.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from scripts.aggregate import _amp_append_allowed
+
+
+def test_amp_append_allowed_whitelist_hosts():
+    assert _amp_append_allowed("rg.ru")
+    assert _amp_append_allowed("www.ria.ru")
+    assert _amp_append_allowed("realty.ria.ru")
+
+
+def test_amp_append_allowed_disallowed_hosts():
+    assert not _amp_append_allowed("example.com")
+    assert not _amp_append_allowed("news.rg.ru")
+    assert not _amp_append_allowed("m.ria.ru")

--- a/tests/test_url_filters.py
+++ b/tests/test_url_filters.py
@@ -12,6 +12,9 @@ from scripts.url_filters import is_listing_url
         "https://example.com/path/?page=2",
         "https://example.com/list/?PAGEN_1=3",
         "https://example.com/poll/?VOTE_ID=12",
+        "https://stroygaz.ru/news/regulation/",
+        "https://stroygaz.ru/news/official/",
+        "https://eec.eaeunion.org/news/speech/",
     ],
 )
 def test_is_listing_url_positive(url):


### PR DESCRIPTION
## Summary
- extend the listing URL detector to treat /news/<slug>/ style section pages as listings and cover the new rule with tests
- add an AMP fallback, richer API body extraction, and per-source micro-news filtering with summary logging in the aggregator, now restricting the /amp fallback to a whitelist and covering the helper with tests
- require at least 100 words for "Стройгаз.ру" items via the new min_words threshold

## Testing
- pytest
- python scripts/aggregate.py --dry-run --smoke --limit-per-source 3 --max-runtime 420

------
https://chatgpt.com/codex/tasks/task_e_68d573b4a010832c8b4cb0846bf8c05f