### PR TITLE
Fix host-specific URL filtering and Stroygaz content fallback

### DIFF
--- a/scripts/url_filters.py
+++ b/scripts/url_filters.py
@@ -17,11 +17,47 @@ _SECTION_PREFIXES = {
     "press-tsentr",
 }
 
+_GENERIC_SECTION_PATHS = {"/press", "/press/", "/news-list", "/news-list/"}
+_GENERIC_QUERY_KEYS = {
+    "page",
+    "pagen_1",
+    "per-page",
+    "tag",
+    "category",
+    "year",
+    "month",
+    "sort",
+    "filter",
+}
+
+_HOST_ALLOW_LIST = {
+    "notim.ru": (re.compile(r"^/news/[^/?#]+/?$"),),
+    "www.notim.ru": (re.compile(r"^/news/[^/?#]+/?$"),),
+    "eec.eaeunion.org": (re.compile(r"^/news/[^/?#]+/?$"),),
+    "www.eec.eaeunion.org": (re.compile(r"^/news/[^/?#]+/?$"),),
+    "erzrf.ru": (re.compile(r"^/news/[^/?#]+/?$"),),
+    "www.erzrf.ru": (re.compile(r"^/news/[^/?#]+/?$"),),
+}
+
+_HOST_LISTING_HUBS = {
+    "eec.eaeunion.org": (re.compile(r"^/news/(speech|events|video-gallery|photo-gallery|broadcasts)/?$"),),
+    "www.eec.eaeunion.org": (re.compile(r"^/news/(speech|events|video-gallery|photo-gallery|broadcasts)/?$"),),
+    "ria-stk.ru": (re.compile(r"^/news/vse-novosti\.php$"),),
+    "www.ria-stk.ru": (re.compile(r"^/news/vse-novosti\.php$"),),
+}
+
 
 def _path_segments(path: str) -> list[str]:
     if not path:
         return []
     return [segment for segment in path.split("/") if segment]
+
+
+def _normalize_host(host: str) -> str:
+    host = host.lower()
+    if host.startswith("www."):
+        return host[4:]
+    return host
 
 
 def is_listing_url(url: str | None) -> bool:
@@ -31,7 +67,52 @@ def is_listing_url(url: str | None) -> bool:
         return False
 
     parsed = urlparse(url)
-    segments = [segment.lower() for segment in _path_segments(parsed.path)]
+    host = parsed.netloc.lower()
+    host_no_www = _normalize_host(host)
+    path = parsed.path or ""
+    normalized_path = path.rstrip("/") or "/"
+    lowered_path = path.lower()
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+
+    hub_patterns = _HOST_LISTING_HUBS.get(host) or _HOST_LISTING_HUBS.get(host_no_www)
+    hub_match = False
+    if hub_patterns:
+        for pattern in hub_patterns:
+            if pattern.match(lowered_path):
+                hub_match = True
+                break
+
+    # Host allow-lists: treat matched URLs as articles regardless of other heuristics.
+    allow_patterns = _HOST_ALLOW_LIST.get(host) or _HOST_ALLOW_LIST.get(host_no_www)
+    if allow_patterns:
+        for pattern in allow_patterns:
+            if pattern.match(path):
+                if hub_match:
+                    break
+                return False
+    if host_no_www == "ria-stk.ru" and re.match(r"^/news/index\.php$", path, re.IGNORECASE):
+        if any(k.lower() == "element_id" and v for k, v in query_pairs):
+            return False
+
+    # Explicit listing hubs that should always be filtered.
+    if normalized_path in {"/news"}:
+        return True
+    if hub_match:
+        return True
+
+    # Generic listing signals.
+    if "/page/" in lowered_path:
+        return True
+    if normalized_path in _GENERIC_SECTION_PATHS:
+        return True
+
+    query_keys_lower = {k.lower() for k, _ in query_pairs}
+    if query_keys_lower & _GENERIC_QUERY_KEYS:
+        return True
+    if any(k.upper().startswith("PAGEN_") for k, _ in query_pairs):
+        return True
+
+    segments = [segment.lower() for segment in _path_segments(path)]
     if segments:
         last_segment = segments[-1]
         if last_segment == "news":
@@ -45,11 +126,10 @@ def is_listing_url(url: str | None) -> bool:
     if any(segment in _LISTING_SEGMENTS for segment in segments):
         return True
 
-    query = parsed.query
-    if not query:
+    if not query_pairs:
         return False
 
-    for key, value in parse_qsl(query, keep_blank_values=True):
+    for key, value in query_pairs:
         if not value or not value.isdigit():
             continue
         if key.lower() == "page":

--- a/sources.json
+++ b/sources.json
@@ -250,10 +250,9 @@
     "min_words": 100,
     "enabled": true,
     "content_selectors": [
-      ".content",
-      ".news-detail",
-      ".article",
-      ".news-text"
+      "[itemprop='articleBody']",
+      "article .content, article .entry-content, article .article-content",
+      ".news__detail, .news__content, .single-news, .post__content, .content-body"
     ]
   },
   {

--- a/tests/test_content_extract.py
+++ b/tests/test_content_extract.py
@@ -1,0 +1,13 @@
+from scripts.aggregate import extract_content_with_fallback
+
+
+def test_not_equals_title():
+    title = "Пример заголовка"
+    html = (
+        "<article><h1>Пример заголовка</h1><div itemprop='articleBody'>"
+        "<p>Тело новости ...</p><p>Еще немного текста.</p></div></article>"
+    )
+    text = extract_content_with_fallback(html, ["[itemprop='articleBody']"], title)
+    assert text.strip()
+    assert text.strip() != title
+    assert len(text) >= 20

--- a/tests/test_url_filters.py
+++ b/tests/test_url_filters.py
@@ -15,6 +15,7 @@ from scripts.url_filters import is_listing_url
         "https://stroygaz.ru/news/regulation/",
         "https://stroygaz.ru/news/official/",
         "https://eec.eaeunion.org/news/speech/",
+        "https://example.com/path/?page=two",
     ],
 )
 def test_is_listing_url_positive(url):
@@ -28,9 +29,35 @@ def test_is_listing_url_positive(url):
         "https://example.com/article/",
         "https://example.com/breaking-news/",
         "https://example.com/path/?homepage=1",
-        "https://example.com/path/?page=two",
         "https://example.com/path/?ref=page",
     ],
 )
 def test_is_listing_url_negative(url):
     assert not is_listing_url(url)
+
+
+def test_host_specific_rules():
+    # NOTIM
+    assert not is_listing_url(
+        "https://notim.ru/news/iskusstvennyy-intellekt-protiv-konservatizma-kak-ii-menyaet-stroitelnuyu-otrasl/"
+    )
+    assert is_listing_url("https://notim.ru/news/?PAGEN_1=3")
+
+    # EEC
+    assert not is_listing_url(
+        "https://eec.eaeunion.org/news/bakytzhan-sagintaev-provel-rabochuyu-vstrechu-s-alekseem-overchukom/"
+    )
+    for hub in ("speech", "events", "video-gallery", "photo-gallery", "broadcasts"):
+        assert is_listing_url(f"https://eec.eaeunion.org/news/{hub}/")
+    assert is_listing_url("https://eec.eaeunion.org/news/?page=2")
+
+    # ERZ.RF
+    assert not is_listing_url(
+        "https://erzrf.ru/news/za-god-predlozheniye-apartamentov-v-moskve-sokratilos-na-tret"
+    )
+    assert is_listing_url("https://erzrf.ru/news/?tag=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0")
+
+    # RIA-STK
+    assert is_listing_url("https://ria-stk.ru/news/vse-novosti.php")
+    assert is_listing_url("https://ria-stk.ru/news/vse-novosti.php?PAGEN_1=2")
+    assert not is_listing_url("https://ria-stk.ru/news/index.php?ELEMENT_ID=244992&all_news=Y")


### PR DESCRIPTION
## Summary
- refine `is_listing_url` with host-specific allow/deny patterns and stronger generic listing heuristics
- add a rich content fallback pipeline for Stroygaz (and similar) articles plus tuned selectors
- extend the test suite to cover the new URL filtering cases and guard against content/title duplication

## Testing
- `pytest`
- `python scripts/aggregate.py --rebuild`


------
https://chatgpt.com/codex/tasks/task_e_68d5d4bb1824832cbcb5780d55667cf1