### PR TITLE
Add fallback start URLs and richer fetch diagnostics

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -1902,6 +1902,10 @@ def harvest_source(src: dict, force: bool = False):
 
     src_name = src.get("name", "")
     start_url = src["start_url"]
+    fallback_start_urls = src.get("fallback_start_urls") or []
+    if isinstance(fallback_start_urls, (str, bytes)):
+        fallback_start_urls = [fallback_start_urls]
+    start_candidates = [start_url] + [u for u in fallback_start_urls if u and u != start_url]
     min_words = SOURCE_MIN_WORDS.get(src_name, DEFAULT_MIN_WORDS)
     SOURCE_SUMMARY[src_name]["min_words"] = min_words
     cache_path = PAGES_DIR / cache_key_for(start_url)
@@ -1945,17 +1949,72 @@ def harvest_source(src: dict, force: bool = False):
 
     logging.info("Harvest: %s — %s", src["name"], start_url)
     if index_html is None:
-        try:
-            index_html = fetch_page(start_url, src=src)
-        except requests.HTTPError as exc:
-            resp = exc.response
-            status = resp.status_code if resp is not None else None
-            if status in {500, 502, 503, 504}:
+        last_exc = None
+        for candidate_idx, candidate_url in enumerate(start_candidates, start=1):
+            logging.info(
+                "Index candidate %d/%d for %s: %s",
+                candidate_idx,
+                len(start_candidates),
+                src.get("name"),
+                candidate_url,
+            )
+            try:
+                index_html = fetch_page(candidate_url, src=src)
+                if candidate_url != src["start_url"]:
+                    logging.info("Index fetched via fallback URL for %s: %s", src.get("name"), candidate_url)
+                start_url = candidate_url
+                cache_path = PAGES_DIR / cache_key_for(start_url)
+                break
+            except (requests.RequestException, SourceTemporarilyUnavailable) as exc:
+                last_exc = exc
+                logging.warning("Index candidate failed for %s: %s (%s)", src.get("name"), candidate_url, exc)
+
+        if index_html is None and last_exc is not None:
+            try:
+                raise last_exc
+            except requests.HTTPError as exc:
+                resp = exc.response
+                status = resp.status_code if resp is not None else None
+                if status in {500, 502, 503, 504}:
+                    cooldowns[start_url] = time.time() + 6 * 3600
+                    if cache_path.exists():
+                        logging.warning(
+                            "Server error %s, using cached index + cooldown 6h: %s — %s",
+                            status,
+                            src.get("name"),
+                            start_url,
+                        )
+                        errors.append(
+                            {
+                                "source": src.get("name"),
+                                "url": start_url,
+                                "error": f"HTTP {status} -> used cache + cooldown 6h",
+                            }
+                        )
+                        index_html = cache_path.read_text(encoding="utf-8")
+                        use_only_cache = True
+                    else:
+                        logging.warning(
+                            "Server error %s, cooldown 6h: %s — %s",
+                            status,
+                            src.get("name"),
+                            start_url,
+                        )
+                        errors.append(
+                            {
+                                "source": src.get("name"),
+                                "url": start_url,
+                                "error": f"HTTP {status} -> cooldown 6h",
+                            }
+                        )
+                        return []
+                else:
+                    raise
+            except requests.exceptions.RetryError as exc:
                 cooldowns[start_url] = time.time() + 6 * 3600
                 if cache_path.exists():
                     logging.warning(
-                        "Server error %s, using cached index + cooldown 6h: %s — %s",
-                        status,
+                        "Server error (retry exhausted), using cached index + cooldown 6h: %s — %s",
                         src.get("name"),
                         start_url,
                     )
@@ -1963,15 +2022,14 @@ def harvest_source(src: dict, force: bool = False):
                         {
                             "source": src.get("name"),
                             "url": start_url,
-                            "error": f"HTTP {status} -> used cache + cooldown 6h",
+                            "error": f"retry exhausted -> used cache + cooldown 6h: {exc}",
                         }
                     )
                     index_html = cache_path.read_text(encoding="utf-8")
                     use_only_cache = True
                 else:
                     logging.warning(
-                        "Server error %s, cooldown 6h: %s — %s",
-                        status,
+                        "Server error (retry exhausted), cooldown 6h: %s — %s",
                         src.get("name"),
                         start_url,
                     )
@@ -1979,74 +2037,41 @@ def harvest_source(src: dict, force: bool = False):
                         {
                             "source": src.get("name"),
                             "url": start_url,
-                            "error": f"HTTP {status} -> cooldown 6h",
+                            "error": f"retry exhausted -> cooldown 6h: {exc}",
                         }
                     )
                     return []
-            else:
-                raise
-        except requests.exceptions.RetryError as exc:
-            cooldowns[start_url] = time.time() + 6 * 3600
-            if cache_path.exists():
+            except SourceTemporarilyUnavailable as exc:
+                failures = STATE.setdefault("stats", {}).setdefault("errors", [])
                 logging.warning(
-                    "Server error (retry exhausted), using cached index + cooldown 6h: %s — %s",
-                    src.get("name"),
-                    start_url,
+                    "Temporary unavailability for %s: %s", src.get("name"), exc
                 )
-                errors.append(
-                    {
-                        "source": src.get("name"),
-                        "url": start_url,
-                        "error": f"retry exhausted -> used cache + cooldown 6h: {exc}",
-                    }
-                )
-                index_html = cache_path.read_text(encoding="utf-8")
-                use_only_cache = True
-            else:
-                logging.warning(
-                    "Server error (retry exhausted), cooldown 6h: %s — %s",
-                    src.get("name"),
-                    start_url,
-                )
-                errors.append(
-                    {
-                        "source": src.get("name"),
-                        "url": start_url,
-                        "error": f"retry exhausted -> cooldown 6h: {exc}",
-                    }
-                )
-                return []
-        except SourceTemporarilyUnavailable as exc:
-            failures = STATE.setdefault("stats", {}).setdefault("errors", [])
-            logging.warning(
-                "Temporary unavailability for %s: %s", src.get("name"), exc
-            )
-            if cache_path.exists():
-                logging.warning(
-                    "Using cached index due to host issue: %s — %s",
-                    src.get("name"),
-                    start_url,
-                )
-                failures.append(
-                    {
-                        "source": src.get("name"),
-                        "url": start_url,
-                        "error": f"temporary unavailable -> used cache: {exc}",
-                        "status": "cached",
-                    }
-                )
-                index_html = cache_path.read_text(encoding="utf-8")
-                use_only_cache = True
-            else:
-                failures.append(
-                    {
-                        "source": src.get("name"),
-                        "url": start_url,
-                        "error": f"temporary unavailable: {exc}",
-                        "status": "skipped",
-                    }
-                )
-                return []
+                if cache_path.exists():
+                    logging.warning(
+                        "Using cached index due to host issue: %s — %s",
+                        src.get("name"),
+                        start_url,
+                    )
+                    failures.append(
+                        {
+                            "source": src.get("name"),
+                            "url": start_url,
+                            "error": f"temporary unavailable -> used cache: {exc}",
+                            "status": "cached",
+                        }
+                    )
+                    index_html = cache_path.read_text(encoding="utf-8")
+                    use_only_cache = True
+                else:
+                    failures.append(
+                        {
+                            "source": src.get("name"),
+                            "url": start_url,
+                            "error": f"temporary unavailable: {exc}",
+                            "status": "skipped",
+                        }
+                    )
+                    return []
 
     # Если содержимое ленты не изменилось — пропускаем весь источник
     idx_digest = hashlib.sha256(index_html.encode("utf-8")).hexdigest()
@@ -2160,6 +2185,8 @@ def harvest_source(src: dict, force: bool = False):
             if len(link_text) < min_len and not src.get("accept_empty_anchor"):
                 continue
         links.append(href)
+
+    logging.info("Link extraction stats for %s: raw=%d accepted=%d", src_name, len(raw_candidates), len(links))
 
     # Dedup and limit
     uniq = []

--- a/scripts/http_client.py
+++ b/scripts/http_client.py
@@ -204,6 +204,7 @@ class HostClient:
             "attempts": 0,
             "status": None,
             "error": None,
+            "attempt_log": [],
         }
 
         attempt = 0
@@ -216,7 +217,6 @@ class HostClient:
             proxy_cfg = proxies or next(proxies_cycle)
             request_headers = dict(headers)
             request_headers.update(self.strategy.extra_headers)
-            dns_started = time.monotonic()
             dns_ms = self._perform_dns_lookup(url)
             request_started = time.monotonic()
             try:
@@ -232,6 +232,24 @@ class HostClient:
                 if dns_ms is not None and metrics["response_ms"] is not None:
                     metrics["connect_ms"] = max(0.0, metrics["response_ms"] - dns_ms)
                 metrics["status"] = response.status_code
+                metrics["attempt_log"].append({
+                    "attempt": attempt,
+                    "status": response.status_code,
+                    "proxy": proxy_cfg,
+                    "dns_ms": dns_ms,
+                    "response_ms": metrics.get("response_ms"),
+                    "final_url": getattr(response, "url", url),
+                })
+                LOGGER.info(
+                    "Fetch attempt host=%s attempt=%d/%d status=%s dns_ms=%s response_ms=%.1f url=%s",
+                    self.host,
+                    attempt,
+                    max(1, self.strategy.max_attempts),
+                    response.status_code,
+                    f"{dns_ms:.1f}" if isinstance(dns_ms, (int, float)) else "n/a",
+                    float(metrics.get("response_ms") or 0.0),
+                    url,
+                )
                 if response.status_code in self.strategy.retry_statuses and attempt < self.strategy.max_attempts:
                     self._handle_retry_status(url, response.status_code)
                     self._backoff(attempt)
@@ -247,6 +265,8 @@ class HostClient:
                 err_text = str(exc)
                 errors.append(err_text)
                 metrics["error"] = err_text
+                metrics["attempt_log"].append({"attempt": attempt, "error": err_text, "proxy": proxy_cfg})
+                LOGGER.warning("Fetch attempt failed host=%s attempt=%d/%d url=%s error=%s", self.host, attempt, max(1, self.strategy.max_attempts), url, err_text)
                 should_switch = self._is_network_unreachable(exc)
                 if should_switch:
                     proxy_cfg = None  # ensure next iteration selects new proxy
@@ -259,6 +279,8 @@ class HostClient:
                 err_text = f"{exc.__class__.__name__}: {exc}"
                 errors.append(err_text)
                 metrics["error"] = err_text
+                metrics["attempt_log"].append({"attempt": attempt, "error": err_text, "proxy": proxy_cfg})
+                LOGGER.warning("Fetch attempt failed host=%s attempt=%d/%d url=%s error=%s", self.host, attempt, max(1, self.strategy.max_attempts), url, err_text)
                 if attempt >= self.strategy.max_attempts:
                     break
                 self._record_failure(err_text)

--- a/sources.json
+++ b/sources.json
@@ -118,7 +118,10 @@
       "selenium_scroll_steps": 3,
       "capture_cookies": true,
       "record_path_on_success": true
-    }
+    },
+    "fallback_start_urls": [
+      "https://www.gge.ru/press-center/news/"
+    ]
   },
   {
     "name": "АНЦБ",
@@ -443,6 +446,9 @@
       "selenium_scroll_steps": 4,
       "capture_cookies": true,
       "record_path_on_success": true
-    }
+    },
+    "fallback_start_urls": [
+      "https://rg.ru/xml/index.xml"
+    ]
   }
 ]

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -218,7 +218,7 @@ def test_warmup_401_without_cookies_uses_selenium(monkeypatch):
     )
     selenium_called = {"count": 0}
 
-    def fake_selenium(url):
+    def fake_selenium(url, force=False):
         selenium_called["count"] += 1
         client._session.cookies.set("__ddgid", "value", domain="example.com", path="/")
         client._store_cookies()
@@ -247,7 +247,7 @@ def test_warmup_401_without_cookies_and_failed_selenium(monkeypatch):
         ]
     )
 
-    def fake_selenium(url):
+    def fake_selenium(url, force=False):
         return False
 
     monkeypatch.setattr(client, "_selenium_warmup", fake_selenium)
@@ -273,7 +273,7 @@ def test_retry_status_401_triggers_selenium(monkeypatch):
     )
     selenium_called = {"count": 0}
 
-    def fake_selenium(url):
+    def fake_selenium(url, force=False):
         selenium_called["count"] += 1
         return True
 


### PR DESCRIPTION
### Motivation
- Some sources (e.g. `gge.ru`, `rg.ru`) are blocked or return 4xx for the primary listing endpoint, so the harvester needs alternate entrypoints and better diagnostics to recover. 
- Current logs lacked per-attempt telemetry, making it hard to determine whether failures came from network, anti-bot, or parsing stages. 
- Avoid touching runtime cache in the PR to prevent conflicts with the repo owner's `.cache/state.json` usage.

### Description
- Implemented per-source `fallback_start_urls` support in `harvest_source()` so the index fetch will try the primary URL and then configured fallbacks in sequence and log each attempt as `Index candidate i/n` (file: `scripts/aggregate.py`).
- Added a link-extraction summary log showing `raw` vs `accepted` counts before deduplication to help distinguish fetch vs filter problems (file: `scripts/aggregate.py`).
- Extended HTTP client metrics with an `attempt_log` and per-attempt logging of `status`, `dns_ms`, `response_ms`, `proxy`, and `final_url`, and warn on per-attempt failures for better root-cause visibility (file: `scripts/http_client.py`).
- Added fallback entries to `sources.json` for problematic sources: `Российская газета: Экономика` falls back to `https://rg.ru/xml/index.xml`, and `Главгосэкспертиза России` includes `https://www.gge.ru/press-center/news/`.
- Updated tests that stub Selenium warm-up to match the `_selenium_warmup(..., force=...)` signature (file: `tests/test_http_client.py`).

### Testing
- Ran `python -m py_compile scripts/aggregate.py scripts/http_client.py` to verify syntax (success).
- Ran unit tests: `pytest -q tests/test_http_client.py tests/test_metrics_tool.py tests/test_api_harvest.py` (all tests passed).
- Performed a targeted rebuild smoke run: `MODE="rebuild" python scripts/aggregate.py --rebuild --smoke --limit-per-source 3 --sources "Главгосэкспертиза России,Российская газета: Экономика"` which demonstrated the new fallback behavior (the `rg.ru` XML fallback succeeded and was logged), while `gge.ru` remained unreachable here because Chromium/Selenium failed to start in this environment (`session not created: Chrome instance exited`).
- No `.cache/` runtime artifacts were included in the PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b7b36b01c832c99adda12ccf0d707)