### PR TITLE
Upgrade GitHub Actions to Node.js 24-compatible releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # кэш страниц (HTML), чтобы экономить запросы
       - name: Restore .cache/pages (HTML cache)
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .cache/pages
           key: pages-${{ hashFiles('sources.json', 'scripts/aggregate.py') }}-${{ github.run_id }}
@@ -34,7 +34,7 @@ jobs:
             pages-
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
### Motivation
- Address the GitHub Actions warning about Node.js 20 deprecation by using action releases that declare Node.js 24.
- Keep the existing workflow logic (checkout, cache, Python setup, build/commit steps) unchanged while removing the deprecation annotation.
- Prevent CI runs from being forced to run on a different Node runtime and avoid noisy warnings or potential runner behavior changes.

### Description
- Updated `.github/workflows/build.yml` to use `actions/checkout@v7` in place of `actions/checkout@v4`.
- Updated `.github/workflows/build.yml` to use `actions/cache@v6` in place of `actions/cache@v4`.
- Updated `.github/workflows/build.yml` to use `actions/setup-python@v7` in place of `actions/setup-python@v5`.
- No other changes to workflow steps or to the Python codebase were made.

### Testing
- Verified workflow action references programmatically (confirmed `actions/checkout@v7`, `actions/cache@v6`, `actions/setup-python@v7`).
- Ran `git diff --check` and the workflow file sanity checks which passed.
- Ran the test suite with `python -m pytest -q`, which produced `71 passed, 4 failed`; the four failures are two `tests/test_merge.py` cases (`test_keeps_existing_content_text_when_new_is_missing`, `test_retains_original_date_when_new_uses_first_seen_fallback`) and two `tests/test_url_filters.py` cases for `https://stroygaz.ru/news/regulation/` and `https://stroygaz.ru/news/official/`, and are unrelated to the workflow action version updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74f4099644832cb93903e524164361)