### PR TITLE
Speed up feed rebuilds: host timeout cooldown, state pruning, and workflow tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.x"
-
-      - name: Install Chromium for Selenium warm-up
-        run: |
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y chromium-browser chromium-chromedriver
+          python-version: "3.12"
+          cache: pip
 
       - name: Install deps
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install --disable-pip-version-check -r requirements.txt
 
       - name: Build feed
         run: |

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -97,7 +97,9 @@ OPTIONAL_ITEM_FIELDS = ("published_at", "canonical_url")
 # Перехваты ошибок/429 и паузы между запросами к одному хосту
 SESSION = requests.Session()
 _retry = Retry(
-    total=5, connect=3, read=3, backoff_factor=1.5,
+    # Keep the generic path resilient without multiplying a 10 second timeout
+    # into ~47 seconds for every cached article on an unavailable host.
+    total=1, connect=1, read=1, backoff_factor=0.5,
     status_forcelist=[429,500,502,503,504],
     allowed_methods=["GET","HEAD"]
 )
@@ -212,6 +214,55 @@ HOST_CONTENT_SELECTORS: dict[str, list[str]] = {
 
 def save_state():
     STATE_FILE.write_text(json.dumps(STATE, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def prune_state(feed_items: list[dict], sources: list[dict]) -> None:
+    """Discard crawl metadata which can no longer affect the bounded feed.
+
+    The feed contains at most ``FEED_MAX_ITEMS`` records, but the historical
+    lookup maps used to grow forever (past 80k entries / 60 MB).  Retaining the
+    live feed, configured indexes and the bounded seen-URL windows preserves
+    stable IDs and conditional requests while keeping checkout/push inexpensive.
+    """
+    active_ids = {item.get("id") for item in feed_items if item.get("id")}
+    active_urls = {
+        value
+        for item in feed_items
+        for value in (item.get("url"), item.get("canonical_url"))
+        if value
+    }
+    for source in sources:
+        active_urls.update(
+            value
+            for value in (source.get("start_url"), source.get("base_url"))
+            if value
+        )
+        active_urls.update(source.get("index_fallback_urls") or [])
+    for urls in STATE.get("seen_urls", {}).values():
+        if isinstance(urls, list):
+            active_urls.update(urls)
+
+    STATE["headers"] = {
+        key: value for key, value in STATE.get("headers", {}).items() if key in active_urls
+    }
+    STATE["first_seen"] = {
+        key: value for key, value in STATE.get("first_seen", {}).items() if key in active_ids
+    }
+    STATE["aliases"] = {
+        key: value
+        for key, value in STATE.get("aliases", {}).items()
+        if key in active_urls or value in active_urls
+    }
+    STATE["content_hashes"] = {
+        key: value
+        for key, value in STATE.get("content_hashes", {}).items()
+        if value in active_urls
+    }
+    STATE["canonical_item_ids"] = {
+        key: value
+        for key, value in STATE.get("canonical_item_ids", {}).items()
+        if key in active_urls or value in active_ids
+    }
 
 
 def runtime_expired() -> bool:
@@ -2659,6 +2710,8 @@ def main():
         STATE.setdefault("stats", {})["last_run"] = datetime.now(timezone.utc).isoformat()
         STATE["stats"]["items"] = existing_count
         if not ARGS.dry_run:
+            existing_items = load_existing_feed_items()
+            prune_state(existing_items, sources)
             save_state()
         logging.info("No new items -> keep existing %s as-is (%d items)", OUT_JSON, existing_count)
         return
@@ -2673,6 +2726,7 @@ def main():
         STATE.setdefault("stats", {})["last_run"] = datetime.now(timezone.utc).isoformat()
         STATE["stats"]["items"] = len(feed["items"])
         if not ARGS.dry_run:
+            prune_state(feed["items"], sources)
             save_state()
         logging.info("Rewrote(existing only) %s (%d items)", OUT_JSON, len(feed["items"]))
         return
@@ -2687,6 +2741,7 @@ def main():
     STATE.setdefault("stats", {})["last_run"] = datetime.now(timezone.utc).isoformat()
     STATE["stats"]["items"] = len(feed["items"])
     if not ARGS.dry_run:
+        prune_state(feed["items"], sources)
         save_state()
     logging.info("Saved feed to %s (%d items)", OUT_JSON, len(feed["items"]))
 

--- a/scripts/http_client.py
+++ b/scripts/http_client.py
@@ -636,10 +636,21 @@ class HostClient:
         proxy_cfg: Optional[Dict[str, str]],
         explicit_proxies: Optional[Dict[str, str]],
     ) -> bool:
-        if not (self._is_network_unreachable(exc) or self._is_connect_timeout(exc)):
+        # A timeout is a host-level failure, not an article-level failure.  Once
+        # the configured attempts are exhausted, short-circuit the rest of the
+        # host for this run so a rebuild can immediately use its page cache.
+        # Without this, an unavailable host with 20 cached articles can consume
+        # 20 * read_timeout seconds (metalinfo.ru previously added ~16 minutes).
+        is_timeout = isinstance(
+            exc,
+            (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout),
+        ) or "timed out" in str(exc).lower()
+        if not (self._is_network_unreachable(exc) or self._is_connect_timeout(exc) or is_timeout):
             return False
 
         max_attempts = max(1, self.strategy.max_attempts)
+        if is_timeout and not self._is_connect_timeout(exc) and attempt < max_attempts:
+            return False
         if attempt >= max_attempts:
             return True
 

--- a/sources.json
+++ b/sources.json
@@ -242,6 +242,12 @@
     "name": "Металлоснабжение и сбыт",
     "base_url": "https://www.metalinfo.ru",
     "start_url": "https://www.metalinfo.ru/ru/news",
+    "request_strategy": {
+      "connect_timeout": 4,
+      "read_timeout": 8,
+      "max_attempts": 1,
+      "backoff_factor": 0
+    },
     "include_patterns": [
       "/ru/news/"
     ],

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -109,6 +109,21 @@ def test_host_client_raises_after_failures(monkeypatch):
         client.get("https://fail.example/path", headers={})
 
 
+def test_read_timeout_activates_host_cooldown(monkeypatch):
+    state = {}
+    strategy = RequestStrategy(max_attempts=1, backoff_factor=0)
+    client = HostClient("slow.example", strategy, state)
+    client._session = DummySession([requests.exceptions.ReadTimeout("read timed out")])
+    monkeypatch.setattr(client, "_perform_dns_lookup", lambda url: 1.0)
+
+    with pytest.raises(SourceTemporarilyUnavailable):
+        client.get("https://slow.example/first", headers={})
+
+    assert client.state_root["failures"]["network_cooldown_until"] > time.time()
+    with pytest.raises(SourceTemporarilyUnavailable, match="cooldown active"):
+        client.get("https://slow.example/second", headers={})
+
+
 def test_build_strategy_registry_skips_without_base_url():
     sources = [
         {"name": "Broken", "request_strategy": {"max_attempts": 2}},

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -1,6 +1,32 @@
 from scripts import aggregate
 
 
+def test_prune_state_keeps_only_feed_and_seen_metadata(monkeypatch):
+    monkeypatch.setattr(
+        aggregate,
+        "STATE",
+        {
+            "headers": {"https://live": {}, "https://old": {}},
+            "first_seen": {"live-id": "now", "old-id": "then"},
+            "seen_urls": {"Source": ["https://seen"]},
+            "aliases": {"https://live": "https://canonical", "https://old": "https://old"},
+            "content_hashes": {"live-hash": "https://canonical", "old-hash": "https://old"},
+            "canonical_item_ids": {"https://live": "live-id", "https://old": "old-id"},
+        },
+    )
+
+    aggregate.prune_state(
+        [{"id": "live-id", "url": "https://live", "canonical_url": "https://canonical"}],
+        [{"start_url": "https://index", "base_url": "https://base"}],
+    )
+
+    assert "https://old" not in aggregate.STATE["headers"]
+    assert aggregate.STATE["first_seen"] == {"live-id": "now"}
+    assert aggregate.STATE["aliases"] == {"https://live": "https://canonical"}
+    assert aggregate.STATE["content_hashes"] == {"live-hash": "https://canonical"}
+    assert aggregate.STATE["canonical_item_ids"] == {"https://live": "live-id"}
+
+
 def test_ensure_state_keys_adds_missing_fields(monkeypatch):
     legacy_state = {
         "headers": {"X-Test": "1"},


### PR DESCRIPTION
### Motivation

- Rebuild runs were spending excessive time retrying unreachable hosts (per-article timeouts multiplied across many cached articles) and the persistent crawl `STATE` grew unbounded causing large commits and slow checkouts. 
- The workflow did unnecessary package installation (Chromium via apt) and lacked pip caching, increasing CI time.

### Description

- Short-circuit host retries on repeated network timeouts by treating `ReadTimeout`/`ConnectTimeout` as host-level failures and activating a per-host cooldown in `scripts/http_client.py` (adjusted logic in `_should_activate_network_cooldown`).
- Reduce generic `requests` retry aggressiveness in `scripts/aggregate.py` by lowering `Retry(total/connect/read)` to avoid multiplying long timeouts for every article request. 
- Add `prune_state(feed_items, sources)` to `scripts/aggregate.py` and call it before saving `STATE`, trimming `headers`, `first_seen`, `aliases`, `content_hashes`, and `canonical_item_ids` to only the active feed items and seen-URL windows so the tracked state no longer grows without bound.
- Add a conservative per-source `request_strategy` for `metalinfo.ru` in `sources.json` to use shorter `connect_timeout`/`read_timeout` and a single attempt to avoid long stalls on that host.
- Update CI workflow `.github/workflows/build.yml` to use `python-version: "3.12"`, enable the built-in pip cache, remove the redundant `pip` upgrade and the apt-based Chromium install, and use a non-verbose pip install invocation.
- Add unit tests covering the new behavior: `test_read_timeout_activates_host_cooldown` in `tests/test_http_client.py` and `test_prune_state_keeps_only_feed_and_seen_metadata` in `tests/test_state_migration.py`.

### Testing

- Compiled modified modules with `python -m py_compile scripts/aggregate.py scripts/http_client.py` and it succeeded. 
- Ran targeted unit tests with `python -m pytest -q tests/test_http_client.py tests/test_state_migration.py tests/test_host_client_selection.py` and all executed tests passed (`19` passed).
- Ran `git diff --check` to validate there were no whitespace/errors and it succeeded. 
- A broader `python -m pytest -q` run prior to a focused fix showed unrelated pre-existing listing/merge tests failing in the tree, while the modified HTTP client and state-pruning tests passed after the fixes; the changes in this PR did not introduce regressions in the adjusted suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a750108aba0832cb616fd60c3f26db9)