### PR TITLE
Add per-source health reporting, metrics check, and CI health step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,13 @@ jobs:
             python scripts/aggregate.py
           fi
 
-      - name: Commit output (docs/unified.json & state)
+      - name: Check source health
+        run: python scripts/metrics.py docs/unified.json --sources sources.json
+
+      - name: Commit output (feed, source health & state)
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/unified.json .cache/state.json || true
+          git add docs/unified.json docs/source-health.json .cache/state.json || true
           git commit -m "Update unified feed [skip ci]" || echo "No changes"
           git push

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -43,6 +43,7 @@ CACHE_DIR = ROOT / ".cache"
 PAGES_DIR = CACHE_DIR / "pages"
 STATE_FILE = CACHE_DIR / "state.json"
 OUT_JSON = DOCS_DIR / "unified.json"
+SOURCE_HEALTH_JSON = DOCS_DIR / "source-health.json"
 
 CONNECT_TIMEOUT = 5.0
 READ_TIMEOUT = 10.0
@@ -70,6 +71,12 @@ SOURCE_SUMMARY: dict[str, dict[str, object]] = defaultdict(
         "api": 0,
         "amp": 0,
         "min_words": DEFAULT_MIN_WORDS,
+        "index_fetch_status": "not_attempted",
+        "raw_link_candidates": 0,
+        "accepted_links": 0,
+        "attempted_articles": 0,
+        "cached_fallback_used": False,
+        "last_error": None,
     }
 )
 SOURCE_MIN_WORDS: dict[str, int] = {}
@@ -1753,16 +1760,20 @@ def harvest_json_source(src: dict, force: bool = False):
         resp.raise_for_status()
     except requests.RequestException as exc:
         logging.warning("API fetch failed for %s: %s", src_name, exc)
+        SOURCE_SUMMARY[src_name]["index_fetch_status"] = "failed"
+        SOURCE_SUMMARY[src_name]["last_error"] = str(exc)
         if src.get("html_fallback_on_empty_api"):
             logging.info("API failed for %s — falling back to HTML index", src_name)
             return harvest_source(src, force=ARGS.rebuild if ARGS else False)
         raise
 
     text = resp.text
+    SOURCE_SUMMARY[src_name]["index_fetch_status"] = "fetched"
     idx_digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
     ih = STATE.setdefault("index_hash", {})
     if not force and ih.get(endpoint) == idx_digest:
         logging.info("Index unchanged (API): %s — %s", src.get("name"), endpoint)
+        SOURCE_SUMMARY[src_name]["index_fetch_status"] = "unchanged"
         return []
     ih[endpoint] = idx_digest
 
@@ -1770,6 +1781,8 @@ def harvest_json_source(src: dict, force: bool = False):
         payload = resp.json()
     except ValueError as exc:
         logging.error("  invalid JSON for %s: %s", src.get("name"), exc)
+        SOURCE_SUMMARY[src_name]["index_fetch_status"] = "parser_error"
+        SOURCE_SUMMARY[src_name]["last_error"] = str(exc)
         if src.get("html_fallback_on_empty_api"):
             logging.info("API invalid JSON for %s — falling back to HTML index", src_name)
             return harvest_source(src, force=ARGS.rebuild if ARGS else False)
@@ -1824,6 +1837,9 @@ def harvest_json_source(src: dict, force: bool = False):
         if len(entries) >= max_links:
             break
 
+    SOURCE_SUMMARY[src_name]["raw_link_candidates"] = len(data)
+    SOURCE_SUMMARY[src_name]["accepted_links"] = len(entries)
+
     entry_urls = [url for url, _, _ in entries]
 
     if force:
@@ -1833,6 +1849,7 @@ def harvest_json_source(src: dict, force: bool = False):
         if not new_entries:
             logging.info("  no new links for %s", src["name"])
             return []
+    SOURCE_SUMMARY[src_name]["attempted_articles"] += len(new_entries)
 
     items = []
     processed_links = []
@@ -1989,6 +2006,7 @@ def harvest_json_source(src: dict, force: bool = False):
             processed_links.append(url)
         except Exception as e:
             logging.warning("  skip %s: %s", url, e)
+            SOURCE_SUMMARY[src_name]["last_error"] = str(e)
 
     attempted_links = bool(processed_links)
 
@@ -2043,6 +2061,8 @@ def harvest_source(src: dict, force: bool = False):
             )
             index_html = cache_path.read_text(encoding="utf-8")
             use_only_cache = True
+            SOURCE_SUMMARY[src_name]["index_fetch_status"] = "cached"
+            SOURCE_SUMMARY[src_name]["cached_fallback_used"] = True
         else:
             logging.warning(
                 "Skip due to active cooldown until %s: %s — %s",
@@ -2100,6 +2120,7 @@ def harvest_source(src: dict, force: bool = False):
                     )
                     continue
                 index_html = candidate_html
+                SOURCE_SUMMARY[src_name]["index_fetch_status"] = "fetched"
                 if candidate_url != src["start_url"]:
                     logging.info("Index fetched via fallback URL for %s: %s", src.get("name"), candidate_url)
                 start_url = candidate_url
@@ -2110,6 +2131,8 @@ def harvest_source(src: dict, force: bool = False):
                 logging.warning("Index candidate failed for %s: %s (%s)", src.get("name"), candidate_url, exc)
 
         if index_html is None and last_exc is not None:
+            SOURCE_SUMMARY[src_name]["index_fetch_status"] = "failed"
+            SOURCE_SUMMARY[src_name]["last_error"] = str(last_exc)
             try:
                 raise last_exc
             except requests.HTTPError as exc:
@@ -2133,6 +2156,8 @@ def harvest_source(src: dict, force: bool = False):
                         )
                         index_html = cache_path.read_text(encoding="utf-8")
                         use_only_cache = True
+                        SOURCE_SUMMARY[src_name]["index_fetch_status"] = "cached"
+                        SOURCE_SUMMARY[src_name]["cached_fallback_used"] = True
                     else:
                         logging.warning(
                             "Server error %s, cooldown 6h: %s — %s",
@@ -2167,6 +2192,8 @@ def harvest_source(src: dict, force: bool = False):
                     )
                     index_html = cache_path.read_text(encoding="utf-8")
                     use_only_cache = True
+                    SOURCE_SUMMARY[src_name]["index_fetch_status"] = "cached"
+                    SOURCE_SUMMARY[src_name]["cached_fallback_used"] = True
                 else:
                     logging.warning(
                         "Server error (retry exhausted), cooldown 6h: %s — %s",
@@ -2202,6 +2229,8 @@ def harvest_source(src: dict, force: bool = False):
                     )
                     index_html = cache_path.read_text(encoding="utf-8")
                     use_only_cache = True
+                    SOURCE_SUMMARY[src_name]["index_fetch_status"] = "cached"
+                    SOURCE_SUMMARY[src_name]["cached_fallback_used"] = True
                 else:
                     failures.append(
                         {
@@ -2218,6 +2247,7 @@ def harvest_source(src: dict, force: bool = False):
     ih = STATE.setdefault("index_hash", {})
     if not force and ih.get(src["start_url"]) == idx_digest:
         logging.info("Index unchanged: %s — %s", src["name"], src["start_url"])
+        SOURCE_SUMMARY[src_name]["index_fetch_status"] = "unchanged"
         return []
     ih[src["start_url"]] = idx_digest
 
@@ -2327,6 +2357,8 @@ def harvest_source(src: dict, force: bool = False):
         links.append(href)
 
     logging.info("Link extraction stats for %s: raw=%d accepted=%d", src_name, len(raw_candidates), len(links))
+    SOURCE_SUMMARY[src_name]["raw_link_candidates"] = len(raw_candidates)
+    SOURCE_SUMMARY[src_name]["accepted_links"] = len(links)
 
     # Dedup and limit
     uniq = []
@@ -2352,6 +2384,7 @@ def harvest_source(src: dict, force: bool = False):
         if not new_links:
             logging.info("  no new links for %s", src["name"])
             return []
+    SOURCE_SUMMARY[src_name]["attempted_articles"] += len(new_links)
 
     items = []
     processed_links = []
@@ -2434,6 +2467,7 @@ def harvest_source(src: dict, force: bool = False):
         except SourceTemporarilyUnavailable as exc:
             page_path = PAGES_DIR / cache_key_for(url)
             if page_path.exists():
+                SOURCE_SUMMARY[src_name]["cached_fallback_used"] = True
                 logging.warning(
                     "  using cached copy for %s due to temporary issue: %s", url, exc
                 )
@@ -2450,6 +2484,7 @@ def harvest_source(src: dict, force: bool = False):
                 logging.warning("  skip %s: %s", url, exc)
         except Exception as e:
             logging.warning("  skip %s: %s", url, e)
+            SOURCE_SUMMARY[src_name]["last_error"] = str(e)
 
     # обновим «виденные» ссылки — держим скользящее окно последних 800
     keep = 800
@@ -2478,6 +2513,30 @@ def log_source_summary() -> None:
             summary.get("amp", 0),
             int(summary.get("min_words", DEFAULT_MIN_WORDS) or 0),
         )
+
+
+def write_source_health_report(sources: list[dict]) -> None:
+    """Persist crawl diagnostics independently from the retained feed."""
+    rows = []
+    for source in sources:
+        if not source.get("enabled", True):
+            continue
+        name = source.get("name", "")
+        summary = SOURCE_SUMMARY[name]
+        rows.append({
+            "source": name,
+            "index_fetch_status": summary.get("index_fetch_status", "not_attempted"),
+            "raw_link_candidates": summary.get("raw_link_candidates", 0),
+            "accepted_links": summary.get("accepted_links", 0),
+            "attempted_articles": summary.get("attempted_articles", 0),
+            "accepted_articles": summary.get("total", 0),
+            "empty_rejections": summary.get("empty", 0),
+            "short_rejections": summary.get("short", 0),
+            "cached_fallback_used": bool(summary.get("cached_fallback_used", False)),
+            "last_error": summary.get("last_error"),
+        })
+    payload = {"generated_at": datetime.now(timezone.utc).isoformat(), "sources": rows}
+    SOURCE_HEALTH_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def build_feed(all_items):
@@ -2690,6 +2749,8 @@ def main():
             all_items.extend(items)
         except Exception as e:
             logging.error("  !! Failed: %s (%s)", src.get("name"), e)
+            SOURCE_SUMMARY[src_name]["index_fetch_status"] = "failed"
+            SOURCE_SUMMARY[src_name]["last_error"] = str(e)
             STATE.setdefault("stats", {}).setdefault("errors", []).append({"source": src.get("name"), "url": src.get("start_url"), "error": str(e)})
 
     if selected_sources and ARGS.sources:
@@ -2713,6 +2774,7 @@ def main():
             existing_items = load_existing_feed_items()
             prune_state(existing_items, sources)
             save_state()
+            write_source_health_report(sources)
         logging.info("No new items -> keep existing %s as-is (%d items)", OUT_JSON, existing_count)
         return
 
@@ -2728,6 +2790,7 @@ def main():
         if not ARGS.dry_run:
             prune_state(feed["items"], sources)
             save_state()
+            write_source_health_report(sources)
         logging.info("Rewrote(existing only) %s (%d items)", OUT_JSON, len(feed["items"]))
         return
 
@@ -2743,6 +2806,7 @@ def main():
     if not ARGS.dry_run:
         prune_state(feed["items"], sources)
         save_state()
+        write_source_health_report(sources)
     logging.info("Saved feed to %s (%d items)", OUT_JSON, len(feed["items"]))
 
     if RUNTIME_EXCEEDED and os.environ.get("CI"):

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+from datetime import datetime, timedelta, timezone
 from typing import Any, Tuple
 
 try:
@@ -42,6 +43,69 @@ def compute_metrics(items: list[dict[str, Any]]) -> dict[str, int]:
     }
 
 
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def compute_source_metrics(
+    items: list[dict[str, Any]],
+    sources: list[dict[str, Any]],
+    *,
+    stale_after: timedelta,
+    now: datetime | None = None,
+) -> tuple[dict[str, int], list[dict[str, Any]]]:
+    """Return aggregate and per-source health for enabled configured sources."""
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    enabled = [source for source in sources if source.get("enabled", True)]
+    report = []
+    for source in enabled:
+        name = str(source.get("name", ""))
+        source_items = [item for item in items if item.get("source") == name]
+        timestamps = []
+        for item in source_items:
+            # Publication time is authoritative; fetch time is its fallback.
+            timestamp = _parse_timestamp(item.get("published_at")) or _parse_timestamp(
+                item.get("fetched_at")
+            )
+            if timestamp is not None:
+                timestamps.append(timestamp)
+        newest = max(timestamps, default=None)
+        report.append(
+            {
+                "source": name,
+                "item_count": len(source_items),
+                "newest_timestamp": newest.isoformat() if newest else None,
+                "stale": newest is not None and newest < now - stale_after,
+            }
+        )
+    totals = {
+        "enabled_sources": len(report),
+        "sources_with_items": sum(row["item_count"] > 0 for row in report),
+        "sources_without_items": sum(row["item_count"] == 0 for row in report),
+        "stale_sources": sum(row["stale"] for row in report),
+    }
+    return totals, report
+
+
+def find_unexpected_empty_sources(
+    source_report: list[dict[str, Any]], allow_empty: set[str]
+) -> list[str]:
+    """List empty enabled sources that are not explicitly exempted."""
+    return [
+        str(row["source"])
+        for row in source_report
+        if row["item_count"] == 0 and row["source"] not in allow_empty
+    ]
+
+
 def check_anti_genie(baseline: dict[str, int], current: dict[str, int]) -> Tuple[bool, str | None]:
     """Ensure totals do not shrink except for removed listings."""
 
@@ -58,6 +122,12 @@ def check_anti_genie(baseline: dict[str, int], current: dict[str, int]) -> Tuple
 def main() -> int:
     parser = argparse.ArgumentParser(description="Compute quick feed metrics")
     parser.add_argument("path", nargs="?", default="docs/unified.json", help="Path to unified feed JSON")
+    parser.add_argument("--sources", default="sources.json", help="Path to source configuration JSON")
+    parser.add_argument("--stale-hours", type=float, default=168, help="Age in hours after which a source is stale")
+    parser.add_argument(
+        "--allow-empty", action="append", default=[], metavar="SOURCE",
+        help="Enabled source allowed to have no items (repeat option or use comma-separated names)",
+    )
     parser.add_argument(
         "--baseline",
         help="Optional baseline feed JSON to enforce anti-genie rule (total can't drop except filtered listings)",
@@ -73,7 +143,29 @@ def main() -> int:
     for key, value in metrics.items():
         print(f"{key}: {value}")
 
+    sources_path = pathlib.Path(args.sources)
+    if not sources_path.exists():
+        raise SystemExit(f"Sources file not found: {sources_path}")
+    sources = json.loads(sources_path.read_text(encoding="utf-8"))
+    if not isinstance(sources, list):
+        raise SystemExit("Unexpected sources structure: expected a list")
+    source_totals, source_report = compute_source_metrics(
+        items, sources, stale_after=timedelta(hours=max(0, args.stale_hours))
+    )
+    for row in source_report:
+        newest = row["newest_timestamp"] or "none"
+        print(f"source: {row['source']} | items={row['item_count']} | newest={newest} | stale={str(row['stale']).lower()}")
+    for key, value in source_totals.items():
+        print(f"{key}: {value}")
+
     exit_code = 0
+    allow_empty = {
+        name.strip() for value in args.allow_empty for name in value.split(",") if name.strip()
+    }
+    unexpected_empty = find_unexpected_empty_sources(source_report, allow_empty)
+    if unexpected_empty:
+        print(f"unexpected_empty_sources: {', '.join(unexpected_empty)}")
+        exit_code = 1
 
     if args.baseline:
         baseline_path = pathlib.Path(args.baseline)

--- a/tests/test_metrics_tool.py
+++ b/tests/test_metrics_tool.py
@@ -1,6 +1,13 @@
 import json
+from datetime import datetime, timedelta, timezone
 
-from scripts.metrics import _load_items, check_anti_genie, compute_metrics
+from scripts.metrics import (
+    _load_items,
+    check_anti_genie,
+    compute_metrics,
+    compute_source_metrics,
+    find_unexpected_empty_sources,
+)
 
 
 def test_compute_metrics_counts(tmp_path):
@@ -39,3 +46,35 @@ def test_check_anti_genie_allows_listing_reduction():
 
     assert ok
     assert message is None
+
+
+NOW = datetime(2026, 8, 6, tzinfo=timezone.utc)
+SOURCES = [
+    {"name": "healthy", "enabled": True},
+    {"name": "missing", "enabled": True},
+    {"name": "disabled", "enabled": False},
+]
+
+
+def test_missing_enabled_source_fails_health_check():
+    _, report = compute_source_metrics([], SOURCES, stale_after=timedelta(days=7), now=NOW)
+    assert find_unexpected_empty_sources(report, set()) == ["healthy", "missing"]
+
+
+def test_stale_source_is_reported():
+    items = [{"source": "healthy", "published_at": "2026-07-01T00:00:00Z"}]
+    totals, report = compute_source_metrics(items, SOURCES, stale_after=timedelta(days=7), now=NOW)
+    assert totals["stale_sources"] == 1
+    assert report[0]["stale"] is True
+
+
+def test_healthy_source_uses_fetch_timestamp_when_publication_is_invalid():
+    items = [{"source": "healthy", "published_at": "not-a-date", "fetched_at": "2026-08-05T00:00:00Z"}]
+    totals, report = compute_source_metrics(items, SOURCES, stale_after=timedelta(days=7), now=NOW)
+    assert totals == {"enabled_sources": 2, "sources_with_items": 1, "sources_without_items": 1, "stale_sources": 0}
+    assert report[0]["newest_timestamp"] == "2026-08-05T00:00:00+00:00"
+
+
+def test_explicitly_exempted_empty_source_passes():
+    _, report = compute_source_metrics([], [{"name": "expected empty"}], stale_after=timedelta(days=7), now=NOW)
+    assert find_unexpected_empty_sources(report, {"expected empty"}) == []


### PR DESCRIPTION
### Motivation

- Provide per-source visibility into index/index-fetch status, link and article counts, rejections and errors to surface source health problems.  
- Fail the metrics check in CI when an enabled source has no items unless it is explicitly allowlisted, so missing sources are noticed early.  
- Persist a small machine-readable health report alongside `docs/unified.json` to enable automated monitoring and debugging of aggregation runs.

### Description

- Extended `scripts/metrics.py` to load `sources.json`, compute per-source item counts and newest publication/fetch timestamps, and expose aggregate metrics `enabled_sources`, `sources_with_items`, `sources_without_items`, and `stale_sources`; added helper `_parse_timestamp`, `compute_source_metrics`, and `find_unexpected_empty_sources`.  
- Added CLI options to the metrics tool: `--sources` (path to `sources.json`), `--stale-hours` (staleness threshold), and repeatable/comma-separated `--allow-empty` to exempt sources from the nonzero exit behavior.  
- Updated `scripts/aggregate.py` to populate `SOURCE_SUMMARY` with diagnostics (index fetch status, `raw_link_candidates`, `accepted_links`, `attempted_articles`, accepted article counts, empty/short rejections, cached fallback usage, and `last_error`) while ensuring unchanged indexes are recorded as `unchanged` rather than treating them as parser failures.  
- Persisted those diagnostics to a machine-readable `docs/source-health.json` via `write_source_health_report` on normal, unchanged-feed, and rebuild paths.  
- Updated `.github/workflows/build.yml` to run the metrics health check (`python scripts/metrics.py docs/unified.json --sources sources.json`) after aggregation and to commit `docs/source-health.json` along with the feed and state.  
- Added unit tests in `tests/test_metrics_tool.py` covering missing enabled sources, stale sources, publication/fetch fallback behavior, and explicitly exempted empty sources.

### Testing

- Ran targeted unit tests with `pytest tests/test_metrics_tool.py tests/test_state_migration.py -q` and the added metrics tests passed (`9 passed`).  
- Verified the metrics tool behavior with `python scripts/metrics.py docs/unified.json --sources sources.json --stale-hours 168`, which printed per-source lines and returned nonzero when unexpected empty enabled sources were found (exit status `1`) as intended.  
- Compiled the updated modules with `python -m py_compile scripts/metrics.py scripts/aggregate.py` with no syntax errors.  
- Ran the full test suite with `python -m pytest -q`, which resulted in `77 passed, 4 failed`; the failures are in existing tests (`tests/test_merge.py` and `tests/test_url_filters.py`) and are unrelated to the newly added metrics/health-reporting logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a750e9c91b0832c8bbd9979f358c5b3)