### PR TITLE
Make publication validation diagnostics explicit and side‑effect free

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os, re, json, logging, pathlib, sys, hashlib, argparse, random, html
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin, urlparse, parse_qsl, urlencode
 
@@ -80,6 +81,9 @@ SOURCE_SUMMARY: dict[str, dict[str, object]] = defaultdict(
         "attempted_articles": 0,
         "cached_fallback_used": False,
         "future_date_rejections": 0,
+        "publication_rejections_by_signal": {},
+        "publication_rejection_samples": [],
+        "maximum_future_offset_seconds": 0,
         "last_error": None,
     }
 )
@@ -93,7 +97,13 @@ HOST_MIN_WORD_OVERRIDES = {
     "faufcc.ru": 70,
 }
 PUBLICATION_CLOCK_SKEW = timedelta(
-    hours=float(os.environ.get("PUBLICATION_CLOCK_SKEW_HOURS", "24"))
+    minutes=float(os.environ.get("PUBLICATION_CLOCK_SKEW_MINUTES", "15"))
+)
+PUBLICATION_TIMEZONE_SKEW = timedelta(
+    hours=float(os.environ.get("PUBLICATION_TIMEZONE_SKEW_HOURS", "26"))
+)
+PUBLICATION_REJECTION_SAMPLE_LIMIT = int(
+    os.environ.get("PUBLICATION_REJECTION_SAMPLE_LIMIT", "5")
 )
 
 ESSENTIAL_ITEM_FIELDS = (
@@ -692,6 +702,35 @@ def finalize_datetime(dt: datetime):
     return clamp_year(dt)
 
 
+@dataclass
+class PublicationDiagnostics:
+    """Explicit sink for diagnostics produced while parsing this crawl only."""
+
+    source: str
+
+    def reject(self, *, signal: str, raw_value: object, url: str, offset: timedelta) -> None:
+        summary = SOURCE_SUMMARY[self.source]
+        counts = summary.setdefault("publication_rejections_by_signal", {})
+        counts[signal] = int(counts.get(signal, 0) or 0) + 1
+        summary["future_date_rejections"] = sum(int(value) for value in counts.values())
+        offset_seconds = max(0, int(offset.total_seconds()))
+        summary["maximum_future_offset_seconds"] = max(
+            int(summary.get("maximum_future_offset_seconds", 0) or 0), offset_seconds
+        )
+        samples = summary.setdefault("publication_rejection_samples", [])
+        if len(samples) < max(0, PUBLICATION_REJECTION_SAMPLE_LIMIT):
+            samples.append({
+                "signal": signal,
+                "raw_value": str(raw_value),
+                "url": url,
+                "future_offset_seconds": offset_seconds,
+                "classification": (
+                    "timezone_scale_skew" if offset <= PUBLICATION_TIMEZONE_SKEW
+                    else "clearly_invalid_future_date"
+                ),
+            })
+
+
 def validate_publication_datetime(
     dt: datetime | None,
     *,
@@ -700,13 +739,16 @@ def validate_publication_datetime(
     source: str | None = None,
     signal: str = "unknown",
     now: datetime | None = None,
-    allowance: timedelta = PUBLICATION_CLOCK_SKEW,
+    allowance: timedelta = PUBLICATION_TIMEZONE_SKEW,
+    diagnostics: PublicationDiagnostics | None = None,
 ) -> datetime | None:
     """Return a normalized, plausible publication time, or reject it.
 
     ``now`` and ``allowance`` are injectable so callers and tests do not need
     to depend on wall-clock time. All extraction paths should pass through
-    this single boundary before a value is stored as ``published_at``.
+    this single boundary before a value is stored as ``published_at``. The
+    default accommodates timezone-scale metadata errors; signals known not to
+    contain a timezone can opt into the smaller clock-skew allowance.
     """
     dt = finalize_datetime(dt)
     if dt is None:
@@ -714,12 +756,15 @@ def validate_publication_datetime(
     reference = finalize_datetime(now or datetime.now(MSK))
     if dt > reference + allowance:
         rejection_count = 1
-        if source:
-            rejection_count = int(
-                SOURCE_SUMMARY[source].get("future_date_rejections", 0) or 0
-            ) + 1
-            SOURCE_SUMMARY[source]["future_date_rejections"] = rejection_count
-        if rejection_count <= 3:
+        if diagnostics is not None:
+            diagnostics.reject(
+                signal=signal,
+                raw_value=raw_value if raw_value is not None else dt.isoformat(),
+                url=url or "",
+                offset=dt - reference,
+            )
+            rejection_count = int(SOURCE_SUMMARY[diagnostics.source]["future_date_rejections"])
+        if diagnostics is not None and rejection_count <= 3:
             logging.warning(
                 "Reject future publication time value=%r url=%s source=%s signal=%s",
                 raw_value if raw_value is not None else dt.isoformat(),
@@ -727,7 +772,7 @@ def validate_publication_datetime(
                 source or "",
                 signal,
             )
-        elif rejection_count == 4:
+        elif diagnostics is not None and rejection_count == 4:
             logging.warning("Suppress further future-date warnings for source=%s", source or "")
         return None
     return dt
@@ -1370,7 +1415,10 @@ def extract_date_candidates(soup: BeautifulSoup):
         uniq.append(s)
     return uniq[:20]
 
-def try_parse_any_date(candidates, *, url=None, source=None, signal="heuristic", now=None):
+def try_parse_any_date(
+    candidates, *, url=None, source=None, signal="heuristic", now=None,
+    diagnostics=None,
+):
     default_base = make_aware_msk(datetime.now(MSK).replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0))
     for raw in candidates:
         s = raw.strip()
@@ -1379,17 +1427,17 @@ def try_parse_any_date(candidates, *, url=None, source=None, signal="heuristic",
             m = re.search(r"(\d{1,2}):(\d{2})", low)
             hh, mm = (int(m.group(1)), int(m.group(2))) if m else (12, 0)
             dt = make_aware_msk(datetime.now(MSK)).replace(hour=hh, minute=mm, second=0, microsecond=0)
-            return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now)
+            return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now, diagnostics=diagnostics)
         if "вчера" in low or "yesterday" in low:
             m = re.search(r"(\d{1,2}):(\d{2})", low)
             hh, mm = (int(m.group(1)), int(m.group(2))) if m else (12, 0)
             dt = make_aware_msk(datetime.now(MSK) - timedelta(days=1)).replace(hour=hh, minute=mm, second=0, microsecond=0)
-            return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now)
+            return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now, diagnostics=diagnostics)
         # Try ISO-like first
         try:
             dt = finalize_datetime(dparser.isoparse(s))
             if dt:
-                return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now)
+                return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now, diagnostics=diagnostics)
         except Exception:
             pass
         # Try generic parser in day-first mode
@@ -1401,7 +1449,7 @@ def try_parse_any_date(candidates, *, url=None, source=None, signal="heuristic",
                 default=default_base,
             ))
             if dt:
-                return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now)
+                return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now, diagnostics=diagnostics)
         except Exception:
             pass
         # Try Russian words
@@ -1409,11 +1457,14 @@ def try_parse_any_date(candidates, *, url=None, source=None, signal="heuristic",
         if dt:
             dt = finalize_datetime(dt)
             if dt:
-                return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now)
+                return validate_publication_datetime(dt, raw_value=s, url=url, source=source, signal=signal, now=now, diagnostics=diagnostics)
     return None
 
 
-def _parse_datetime_signal(value: str | None, signal: str, *, url=None, source=None, now=None) -> datetime | None:
+def _parse_datetime_signal(
+    value: str | None, signal: str, *, url=None, source=None, now=None,
+    diagnostics=None,
+) -> datetime | None:
     if not value:
         return None
     value = value.strip()
@@ -1442,12 +1493,18 @@ def _parse_datetime_signal(value: str | None, signal: str, *, url=None, source=N
     if dt:
         logging.debug("Published time signal (%s): %s -> %s", signal, value, dt.isoformat())
         return validate_publication_datetime(
-            dt, raw_value=value, url=url, source=source, signal=signal, now=now
+            dt, raw_value=value, url=url, source=source, signal=signal, now=now,
+            diagnostics=diagnostics,
         )
     return None
 
 
-def extract_published_datetime(soup: BeautifulSoup, url: str | None = None, source: str | None = None) -> datetime | None:
+def extract_published_datetime(
+    soup: BeautifulSoup,
+    url: str | None = None,
+    source: str | None = None,
+    diagnostics: PublicationDiagnostics | None = None,
+) -> datetime | None:
     seen_candidates: set[tuple[str, str]] = set()
 
     def attempt(value: str | None, signal: str) -> datetime | None:
@@ -1460,7 +1517,7 @@ def extract_published_datetime(soup: BeautifulSoup, url: str | None = None, sour
         if key in seen_candidates:
             return None
         seen_candidates.add(key)
-        return _parse_datetime_signal(candidate, signal, url=url, source=source)
+        return _parse_datetime_signal(candidate, signal, url=url, source=source, diagnostics=diagnostics)
 
     # Primary meta tags.
     for tag in soup.find_all("meta", attrs={"property": "article:published_time"}):
@@ -1664,6 +1721,7 @@ def build_item(
     src: dict | None = None,
     pre_extracted_content: str | None = None,
 ):
+    publication_diagnostics = PublicationDiagnostics(source_name)
     amp_used = False
     selectors = content_selectors
     content_text: str | None
@@ -1698,7 +1756,9 @@ def build_item(
                 content_source = amp_label or amp_source or "amp"
                 amp_used = True
 
-    dt = extract_published_datetime(soup, url, source_name)
+    dt = extract_published_datetime(
+        soup, url, source_name, diagnostics=publication_diagnostics
+    )
 
     if dt is None:
         m = re.search(r"/(20\d{2})/([01]\d)/([0-3]\d)/", url)
@@ -1711,6 +1771,8 @@ def build_item(
                     url=url,
                     source=source_name,
                     signal="url:path",
+                    diagnostics=publication_diagnostics,
+                    allowance=PUBLICATION_CLOCK_SKEW,
                 )
             except ValueError:
                 dt = None
@@ -2078,13 +2140,15 @@ def harvest_json_source(src: dict, force: bool = False):
             parsed_dt = None
             if date_val:
                 parsed_dt = _parse_datetime_signal(
-                    date_val, "api:date", url=url, source=src_name
+                    date_val, "api:date", url=url, source=src_name,
+                    diagnostics=PublicationDiagnostics(src_name),
                 )
             if not parsed_dt:
                 human_date = _first_non_empty(containers, API_DATE_HUMAN_KEYS)
                 if human_date:
                     parsed_dt = try_parse_any_date(
-                        [human_date], url=url, source=src_name, signal="api:human_date"
+                        [human_date], url=url, source=src_name, signal="api:human_date",
+                        diagnostics=PublicationDiagnostics(src_name),
                     )
             if parsed_dt:
                 item["published_at"] = parsed_dt.isoformat()
@@ -2665,6 +2729,15 @@ def write_source_health_report(sources: list[dict]) -> None:
             "empty_rejections": summary.get("empty", 0),
             "short_rejections": summary.get("short", 0),
             "future_date_rejections": summary.get("future_date_rejections", 0),
+            "publication_rejections_by_signal": summary.get(
+                "publication_rejections_by_signal", {}
+            ),
+            "publication_rejection_samples": summary.get(
+                "publication_rejection_samples", []
+            ),
+            "maximum_future_offset_seconds": summary.get(
+                "maximum_future_offset_seconds", 0
+            ),
             "cached_fallback_used": bool(summary.get("cached_fallback_used", False)),
             "last_error": summary.get("last_error"),
         })

--- a/tests/test_date_extract.py
+++ b/tests/test_date_extract.py
@@ -81,3 +81,49 @@ def test_merge_removes_preexisting_future_publication_date(fixed_now):
 
     assert "published_at" not in merged[0]
     assert merged[0]["fetched_at"] == "2024-10-05T09:00:00+03:00"
+
+
+def test_merging_retained_items_does_not_change_crawl_rejection_counters(fixed_now):
+    aggregate.SOURCE_SUMMARY.clear()
+    retained = [{
+        "id": "article-1",
+        "source": "Example",
+        "title": "Article",
+        "url": "https://example.com/article",
+        "content_text": "content",
+        "first_seen": "2024-10-05T08:00:00+03:00",
+        "bucketed_at": "2024-10-05T08:00:00+03:00",
+        "fetched_at": "2024-10-05T09:00:00+03:00",
+        "published_at": "2025-02-05T10:00:00+03:00",
+    }]
+
+    aggregate.merge_items(retained, [])
+    aggregate.build_feed(retained)
+
+    assert dict(aggregate.SOURCE_SUMMARY) == {}
+
+
+def test_explicit_publication_diagnostics_are_bounded_and_structured(
+    fixed_now, monkeypatch
+):
+    aggregate.SOURCE_SUMMARY.clear()
+    monkeypatch.setattr(aggregate, "PUBLICATION_REJECTION_SAMPLE_LIMIT", 1)
+    diagnostics = aggregate.PublicationDiagnostics("Example")
+
+    for value in ("2024-10-06T13:00:00+03:00", "2025-02-05T10:00:00+03:00"):
+        assert aggregate._parse_datetime_signal(
+            value,
+            "api:date",
+            url="https://example.com/article",
+            source="Example",
+            diagnostics=diagnostics,
+        ) is None
+
+    summary = aggregate.SOURCE_SUMMARY["Example"]
+    assert summary["publication_rejections_by_signal"] == {"api:date": 2}
+    assert len(summary["publication_rejection_samples"]) == 1
+    assert (
+        summary["publication_rejection_samples"][0]["raw_value"]
+        == "2024-10-06T13:00:00+03:00"
+    )
+    assert summary["maximum_future_offset_seconds"] > 0


### PR DESCRIPTION
### Motivation

- Publication date parsing should not increment current-crawl rejection counters during passive normalization of existing records. 
- Freshly fetched HTML/API records still need operational diagnostics for health reporting, sampling, and alerting. 
- Make tolerances for clock skew vs timezone-scale errors configurable and record structured samples for debugging.

### Description

- Make validation side‑effect free by default by adding an explicit `PublicationDiagnostics` collector and changing `validate_publication_datetime` to accept an optional `diagnostics` argument and an `allowance` parameter. 
- Add structured health fields to `SOURCE_SUMMARY`: `publication_rejections_by_signal`, `publication_rejection_samples`, and `maximum_future_offset_seconds`, and wire them into `write_source_health_report`. 
- Introduce configurable parameters `PUBLICATION_REJECTION_SAMPLE_LIMIT`, `PUBLICATION_TIMEZONE_SKEW`, and switch `PUBLICATION_CLOCK_SKEW` to a minutes-based env var, and use the timezone-scale skew as the default allowance while allowing callers to opt into the smaller clock-skew allowance. 
- Only newly parsed items (HTML/API) pass a `PublicationDiagnostics` instance when extracting/normalizing `published_at` (e.g. in `build_item` and JSON harvest paths), while historical/merge/finalize codepaths call the validator without diagnostics so they do not increment current-crawl counters; changes are in `scripts/aggregate.py` and tests in `tests/test_date_extract.py`.

### Testing

- Added regression tests in `tests/test_date_extract.py` that assert merging retained items does not change crawl rejection counters and that diagnostics sampling is bounded and structured. 
- Ran the full test suite with `python -m pytest -q` and all tests passed: `113 passed` with one BeautifulSoup XML parsing warning. 
- Verified the modified health report includes the new diagnostics fields and that freshly parsed items record rejection samples only when an explicit diagnostics collector is provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75e6fcd65c832ca9e6681edf7f5836)