### PR TITLE
Repair aggregate: restore session-state handling and missing import

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -3342,6 +3342,8 @@ def main():
     if SOURCE_HEALTH_STATE_FILE.exists():
         loaded_health_state = json.loads(SOURCE_HEALTH_STATE_FILE.read_text(encoding="utf-8"))
         SOURCE_HEALTH_STATE = loaded_health_state if isinstance(loaded_health_state, dict) else {}
+    else:
+        SOURCE_HEALTH_STATE = {}
 
     SOURCE_SUMMARY.clear()
     SOURCE_MIN_WORDS.clear()

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os, re, json, logging, pathlib, sys, hashlib, argparse, random, html, shutil
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin, urlparse, parse_qsl, urlencode
 
@@ -42,6 +43,7 @@ DOCS_DIR = ROOT / "docs"
 CACHE_DIR = ROOT / ".cache"
 PAGES_DIR = CACHE_DIR / "pages"
 STATE_FILE = CACHE_DIR / "state.json"
+SESSION_STATE_FILE = CACHE_DIR / "session-state.json"
 SOURCE_HEALTH_STATE_FILE = CACHE_DIR / "source-health-state.json"
 OUT_JSON = DOCS_DIR / "unified.json"
 EXISTING_FEED_JSON = OUT_JSON
@@ -168,6 +170,14 @@ def ensure_state_keys(state: dict) -> dict:
         val = state.get(key)
         if not isinstance(val, dict):
             state[key] = dict(default)
+    return state
+
+
+def ensure_session_state_keys(state: dict) -> dict:
+    """Normalize state that is meaningful only to a particular runner."""
+    for key in ("host_state", "stats"):
+        if not isinstance(state.get(key), dict):
+            state[key] = {}
     return state
 
 
@@ -320,6 +330,28 @@ else:
 
 STATE = ensure_state_keys(STATE)
 
+# Runner-specific throttling and diagnostics are cached separately from the
+# durable crawler state committed by the workflow.
+_legacy_host_state = STATE.pop("host_state", {})
+_legacy_stats = STATE.get("stats", {})
+_legacy_session_stats = {
+    key: _legacy_stats.pop(key)
+    for key in ("cooldowns", "errors", "metrics")
+    if key in _legacy_stats
+}
+if not _legacy_stats:
+    STATE.pop("stats", None)
+
+if SESSION_STATE_FILE.exists():
+    SESSION_STATE = json.loads(SESSION_STATE_FILE.read_text(encoding="utf-8"))
+else:
+    SESSION_STATE = {}
+SESSION_STATE = ensure_session_state_keys(SESSION_STATE)
+if _legacy_host_state and not SESSION_STATE["host_state"]:
+    SESSION_STATE["host_state"] = _legacy_host_state
+for key, value in _legacy_session_stats.items():
+    SESSION_STATE["stats"].setdefault(key, value)
+
 if SOURCE_HEALTH_STATE_FILE.exists():
     SOURCE_HEALTH_STATE = json.loads(SOURCE_HEALTH_STATE_FILE.read_text(encoding="utf-8"))
 else:
@@ -386,6 +418,9 @@ HOST_CONTENT_SELECTORS: dict[str, list[str]] = {
 def save_state():
     STATE.pop("source_health_streaks", None)
     STATE_FILE.write_text(json.dumps(STATE, ensure_ascii=False, indent=2), encoding="utf-8")
+    SESSION_STATE_FILE.write_text(
+        json.dumps(SESSION_STATE, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 def save_source_health_state():
@@ -2997,7 +3032,7 @@ def write_source_health_report(sources: list[dict]) -> None:
     # Keep the three stages independent: a 200 response does not mean that the
     # index yielded links, and discovered links do not mean article extraction
     # succeeded.
-    legacy_streaks = STATE.setdefault("source_health_streaks", {})
+    legacy_streaks = SOURCE_HEALTH_STATE
     fetch_streaks = STATE.setdefault("source_fetch_failure_streaks", {})
     discovery_streaks = STATE.setdefault("source_discovery_failure_streaks", {})
     article_streaks = STATE.setdefault("source_article_failure_streaks", {})
@@ -3067,6 +3102,7 @@ def write_source_health_report(sources: list[dict]) -> None:
             "consecutive_article_failures": article_streak,
             "raw_link_candidates": raw_candidates,
             "accepted_links": accepted_links,
+            "index_attempts": summary.get("index_attempts", []),
             "last_successful_discovery_at": source_discovery.get("last_successful_discovery_at"),
             "attempted_articles": attempted,
             "accepted_articles": accepted,

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -1,6 +1,36 @@
 import json
+import sys
 
 from scripts import aggregate
+
+
+def test_main_resets_health_state_for_missing_selected_file(tmp_path, monkeypatch):
+    (tmp_path / "sources.json").write_text("[]", encoding="utf-8")
+    health_state_path = tmp_path / "new-health-state.json"
+    monkeypatch.setattr(aggregate, "ROOT", tmp_path)
+    monkeypatch.setattr(aggregate, "SOURCE_HEALTH_STATE", {"unrelated source": 4})
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "aggregate.py",
+            "--dry-run",
+            "--output",
+            str(tmp_path / "unified.json"),
+            "--existing-feed",
+            str(tmp_path / "existing.json"),
+            "--state-output",
+            str(tmp_path / "state.json"),
+            "--source-health-output",
+            str(tmp_path / "source-health.json"),
+            "--source-health-state",
+            str(health_state_path),
+        ],
+    )
+
+    aggregate.main()
+
+    assert aggregate.SOURCE_HEALTH_STATE == {}
 
 
 def test_prune_state_keeps_only_feed_and_seen_metadata(monkeypatch):


### PR DESCRIPTION
### Motivation
- Recent merge conflict resolution removed the `dataclass` import and parts of session-state handling which caused `NameError: dataclass` and `NameError: SESSION_STATE` at runtime and broke health reporting.
- The intent is to restore runner-specific session state (throttling/diagnostics) separately from durable crawler state and keep legacy health streaks in their dedicated file.

### Description
- Reintroduced the missing import `from dataclasses import dataclass` required by article validation records and other dataclass usages.
- Added `SESSION_STATE_FILE = CACHE_DIR / "session-state.json"`, `ensure_session_state_keys()` and initialization/migration logic to reconstruct `SESSION_STATE` while preserving legacy runner fields moved out of `STATE`.
- Persist `SESSION_STATE` from `save_state()` to avoid runtime `SESSION_STATE` being undefined and avoid polluting durable `STATE` with runner-only data.
- Use `SOURCE_HEALTH_STATE` (separate health-state file) for legacy streaks and expose per-index `index_attempts` diagnostics in `write_source_health_report()` for better health reporting.

### Testing
- Ran `pytest -q` which produced `138 passed, 3 warnings` (BeautifulSoup XML parser warnings) indicating test suite success.
- Ran `python -m compileall -q scripts tests` and `python scripts/aggregate.py --help` which completed without errors.
- Verified repository checks with `git diff --check` and committed the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75f4e719b4832cb09663443c911e0c)