### PR TITLE
Soft-share feed retention and RG sitemap-aware discovery

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -92,6 +92,7 @@ SOURCE_SUMMARY: dict[str, dict[str, object]] = defaultdict(
     }
 )
 SOURCE_MIN_WORDS: dict[str, int] = {}
+SOURCE_RETENTION_WEIGHTS: dict[str, float] = {}
 DEFAULT_MIN_WORDS = 100
 HOST_MIN_WORD_OVERRIDES = {
     "realty.ria.ru": 120,
@@ -2527,32 +2528,47 @@ def extract_index_links(
 
     include_res = compile_patterns("include_regex")
     exclude_res = compile_patterns("exclude_regex")
-    raw_candidates: list[tuple[str, str, bool]] = []
+    # Keep discovery metadata attached to its URL.  In particular, sitemap
+    # category data must not be discarded and then reconstructed from article
+    # text after an expensive fetch.
+    raw_candidates: list[tuple[str, str, bool, str]] = []
     for anchor in soup.find_all("a"):
         href = anchor.get("href")
         if href:
-            raw_candidates.append((href, anchor.get_text(strip=True) or "", True))
+            raw_candidates.append((href, anchor.get_text(strip=True) or "", True, ""))
     for tag_name in ("loc", "link"):
         for tag in soup.find_all(tag_name):
             value = tag.get_text(strip=True)
             if value.startswith("http"):
-                raw_candidates.append((value, value, False))
-    if src.get("parse_embedded_links"):
+                record = tag.find_parent("url") or tag.parent
+                metadata = " ".join(
+                    node.get_text(" ", strip=True)
+                    for node in record.find_all(True)
+                    if node.name.split(":")[-1].lower()
+                    in {"category", "keywords", "subject", "section", "rubric"}
+                )
+                raw_candidates.append((value, value, False, metadata))
+    discovery_categories = src.get("discovery_categories") or []
+    if isinstance(discovery_categories, str):
+        discovery_categories = [discovery_categories]
+    category_terms = [str(term).casefold() for term in discovery_categories if term]
+    metadata_available = bool(category_terms and any(candidate[3] for candidate in raw_candidates))
+    if src.get("parse_embedded_links") and not metadata_available:
         include_snippets = [str(pattern) for pattern in include_patterns]
         for expanded_html in _embedded_text_variants(index_html):
             raw_candidates.extend(
-                (match, "", False)
+                (match, "", False, "")
                 for match in re.findall(r'https?://[^\s"\'<>]+', expanded_html)
             )
             for relative in re.findall(r'"(/[^"<>\s]{6,260})"', expanded_html):
                 if not include_snippets or any(part in relative for part in include_snippets):
-                    raw_candidates.append((relative, "", False))
+                    raw_candidates.append((relative, "", False, ""))
 
     base_url = src["base_url"]
     base_host = urlparse(base_url).netloc.removeprefix("www.")
     current_index = index_url or src["start_url"]
     accepted = []
-    for raw_href, link_text, is_anchor in raw_candidates:
+    for raw_href, link_text, is_anchor, metadata in raw_candidates:
         href = urljoin(base_url, raw_href)
         if href.rstrip("/") == current_index.rstrip("/") or is_listing_url(href, start_url=current_index):
             continue
@@ -2565,6 +2581,8 @@ def extract_index_links(
         if include_res and not any(pattern.search(href) for pattern in include_res):
             continue
         if exclude_res and any(pattern.search(href) for pattern in exclude_res):
+            continue
+        if metadata_available and not any(term in metadata.casefold() for term in category_terms):
             continue
         if is_anchor:
             min_len = int(src.get("link_min_text_len", 0))
@@ -3131,7 +3149,12 @@ def write_source_health_report(sources: list[dict]) -> None:
 
 
 def retain_bounded_items(items: list[dict]) -> list[dict]:
-    """Apply fair, deterministic retention to an already newest-first list."""
+    """Reserve source minima, then allocate soft weighted shares.
+
+    A source's next item scores ``weight / (already_selected + 1)``.  Thus a
+    deep dominant queue progressively yields to specialist queues, but remains
+    eligible and can consume every unfilled slot once those queues run dry.
+    """
     if not FEED_MAX_ITEMS or len(items) <= FEED_MAX_ITEMS:
         return items
     if FEED_MIN_ITEMS_PER_SOURCE <= 0:
@@ -3148,22 +3171,30 @@ def retain_bounded_items(items: list[dict]) -> list[dict]:
             counts[source] += 1
     if len(reserved) > FEED_MAX_ITEMS:
         return items[:FEED_MAX_ITEMS]
-    remainder = [
-        item for item in items
-        if str(item.get("id") or item.get("url") or "") not in reserved_ids
-    ]
-    combined = reserved + remainder
-    combined.sort(
-        key=lambda x: x.get("published_at") or x.get("fetched_at") or x.get("first_seen") or "",
-        reverse=True,
-    )
-    selected_ids = {
-        str(item.get("id") or item.get("url") or "") for item in reserved
-    }
-    # Keep reservations even when they are older than the global cutoff.
     selected = list(reserved)
-    selected.extend(item for item in combined if str(item.get("id") or item.get("url") or "") not in selected_ids)
-    selected = selected[:FEED_MAX_ITEMS]
+    queues: dict[str, list[tuple[int, dict]]] = defaultdict(list)
+    for position, item in enumerate(items):
+        item_id = str(item.get("id") or item.get("url") or "")
+        if item_id not in reserved_ids:
+            queues[str(item.get("source") or "")].append((position, item))
+
+    while len(selected) < FEED_MAX_ITEMS and queues:
+        eligible = [source for source, queue in queues.items() if queue]
+        if not eligible:
+            break
+        source = min(
+            eligible,
+            key=lambda name: (
+                -(max(0.01, SOURCE_RETENTION_WEIGHTS.get(name, 1.0)) / (counts[name] + 1)),
+                queues[name][0][0],
+                name,
+            ),
+        )
+        _, item = queues[source].pop(0)
+        selected.append(item)
+        counts[source] += 1
+        if not queues[source]:
+            del queues[source]
     selected.sort(
         key=lambda x: x.get("published_at") or x.get("fetched_at") or x.get("first_seen") or "",
         reverse=True,
@@ -3365,6 +3396,14 @@ def main():
             ARGS.limit_per_source = 3
 
     sources = json.loads((ROOT / "sources.json").read_text(encoding="utf-8"))
+    SOURCE_RETENTION_WEIGHTS.clear()
+    for source in sources:
+        configured_weight = source.get("retention_weight", 1.0)
+        try:
+            SOURCE_RETENTION_WEIGHTS[source.get("name", "")] = max(0.01, float(configured_weight))
+        except (TypeError, ValueError):
+            logging.warning("Invalid retention_weight for %s; using 1.0", source.get("name"))
+            SOURCE_RETENTION_WEIGHTS[source.get("name", "")] = 1.0
     HOST_STRATEGIES.update(build_strategy_registry(sources))
 
     selected_sources = None

--- a/sources.json
+++ b/sources.json
@@ -467,6 +467,7 @@
       "/20"
     ],
     "link_min_text_len": 8,
+    "retention_weight": 0.75,
     "enabled": true,
     "content_selectors": [
       "article .article__body",
@@ -512,6 +513,22 @@
     },
     "fallback_start_urls": [
       "https://rg.ru/xml/index.xml"
+    ],
+    "discovery_categories": [
+      "эконом",
+      "строител",
+      "недвижим",
+      "жиль",
+      "инфраструктур",
+      "стандарт",
+      "регулирован",
+      "economics",
+      "construction",
+      "real estate",
+      "housing",
+      "infrastructure",
+      "standards",
+      "regulatory"
     ]
   }
 ]

--- a/tests/fixtures/rg.ru/index.xml
+++ b/tests/fixtures/rg.ru/index.xml
@@ -1,1 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?><urlset><url><loc>https://rg.ru/2026/08/06/contract-fixture.html</loc></url></urlset>
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  <url>
+    <loc>https://rg.ru/2026/08/06/contract-fixture.html</loc>
+    <news:news><news:keywords>Экономика, строительство, инфраструктура</news:keywords></news:news>
+  </url>
+  <url>
+    <loc>https://rg.ru/2026/08/06/unrelated-sports-fixture.html</loc>
+    <news:news><news:keywords>Спорт, футбол</news:keywords></news:news>
+  </url>
+</urlset>

--- a/tests/test_retention_and_cache.py
+++ b/tests/test_retention_and_cache.py
@@ -28,6 +28,46 @@ def test_fair_retention_reserves_items_for_low_volume_sources(monkeypatch):
     assert retained == sorted(retained, key=lambda item: item["published_at"], reverse=True)
 
 
+def test_soft_shares_materially_improve_specialist_representation(monkeypatch):
+    monkeypatch.setattr(aggregate, "FEED_MAX_ITEMS", 12)
+    monkeypatch.setattr(aggregate, "FEED_MIN_ITEMS_PER_SOURCE", 1)
+    monkeypatch.setattr(aggregate, "SOURCE_RETENTION_WEIGHTS", {})
+    items = [_item("dominant", day) for day in range(20, 0, -1)]
+    items += [_item("planning", day) for day in range(3, 0, -1)]
+    items += [_item("standards", day) for day in range(3, 0, -1)]
+
+    retained = aggregate.retain_bounded_items(items)
+
+    assert sum(item["source"] != "dominant" for item in retained) == 6
+
+
+def test_soft_shares_leave_no_capacity_unused(monkeypatch):
+    monkeypatch.setattr(aggregate, "FEED_MAX_ITEMS", 8)
+    monkeypatch.setattr(aggregate, "FEED_MIN_ITEMS_PER_SOURCE", 1)
+    monkeypatch.setattr(aggregate, "SOURCE_RETENTION_WEIGHTS", {"dominant": 0.25})
+    items = [_item("dominant", day) for day in range(10, 0, -1)] + [_item("specialist", 1)]
+
+    retained = aggregate.retain_bounded_items(items)
+
+    assert len(retained) == 8
+    assert sum(item["source"] == "dominant" for item in retained) == 7
+
+
+def test_soft_share_result_is_newest_first_with_stable_source_order(monkeypatch):
+    monkeypatch.setattr(aggregate, "FEED_MAX_ITEMS", 7)
+    monkeypatch.setattr(aggregate, "FEED_MIN_ITEMS_PER_SOURCE", 1)
+    monkeypatch.setattr(aggregate, "SOURCE_RETENTION_WEIGHTS", {})
+    items = [_item("dominant", day) for day in range(9, 0, -1)]
+    items += [_item("specialist", day) for day in range(3, 0, -1)]
+
+    retained = aggregate.retain_bounded_items(items)
+
+    assert retained == sorted(retained, key=lambda item: item["published_at"], reverse=True)
+    for source in {item["source"] for item in retained}:
+        source_dates = [item["published_at"] for item in retained if item["source"] == source]
+        assert source_dates == sorted(source_dates, reverse=True)
+
+
 def test_page_cache_pruning_removes_old_then_excess_files(tmp_path, monkeypatch):
     monkeypatch.setattr(aggregate, "PAGES_DIR", tmp_path)
     monkeypatch.setattr(aggregate, "CACHE_MAX_AGE_DAYS", 2)

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -88,13 +88,21 @@ def test_xml_fallback_index_contract(monkeypatch):
     expected = json.loads((directory / "expected.json").read_text())
     xml_index = (directory / "index.xml").read_text()
     article = (directory / "article.html").read_text()
-    monkeypatch.setattr(
-        aggregate,
-        "fetch_page",
-        lambda url, src=None: xml_index if url == source["start_url"] else article,
-    )
+    unrelated = "https://rg.ru/2026/08/06/unrelated-sports-fixture.html"
+
+    def fixture_fetch(url, src=None):
+        if url == source["start_url"]:
+            return xml_index
+        if url == expected["article_url"]:
+            return article
+        raise AssertionError(f"unrelated sitemap record was fetched: {url}")
+
+    monkeypatch.setattr(aggregate, "fetch_page", fixture_fetch)
     monkeypatch.setattr(aggregate, "fetch_amp_if_available", lambda *args, **kwargs: (None, None))
-    assert expected["article_url"] in [item["url"] for item in aggregate.harvest_source(source, force=True)]
+    items = aggregate.harvest_source(source, force=True)
+    assert [item["url"] for item in items] == [expected["article_url"]]
+    assert aggregate.STATE["candidate_urls"][source["name"]] == [expected["article_url"]]
+    assert unrelated not in aggregate.STATE["candidate_urls"][source["name"]]
 
 
 def test_fallback_skips_anchor_page_without_accepted_articles(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation

- Replace the previous minimum-only per-source retention so specialist sources get materially better representation while still allowing high-volume sources to fill unused capacity. 
- Allow per-source tuning of preferred share via a configurable weight to control competitive allocation without hard ceilings. 
- Constrain Russian Gazette discovery using sitemap/category metadata so only economics-related records are fetched, avoiding a global keyword blacklist.

### Description

- Replace the simple minima-only selection in `retain_bounded_items` with a soft-share allocator that reserves per-source minima and then picks additional items by scoring `weight / (already_selected + 1)` so dominant sources progressively yield to specialists but may fill remaining slots. (`scripts/aggregate.py`)
- Add `SOURCE_RETENTION_WEIGHTS` and load optional `retention_weight` from `sources.json` with validation and a sensible default of `1.0`. (`scripts/aggregate.py`, `sources.json`)
- Preserve discovery metadata when parsing indexes (including sitemap/news category/keywords tags) and add an optional `discovery_categories` per-source config; when category metadata is present, filter candidates against it before fetching articles. (`scripts/aggregate.py`, `sources.json`)
- Update Russian Gazette configuration to include `retention_weight` and a list of `discovery_categories` targeting economics, construction, real estate, housing, infrastructure, standards, and regulatory subject areas. (`sources.json`)
- Extend automated coverage: add soft-share retention tests to `tests/test_retention_and_cache.py`, add sitemap records and stricter assertions to `tests/test_source_contracts.py`, and extend the RG XML fixture `tests/fixtures/rg.ru/index.xml` with both relevant and unrelated records to verify category filtering. (`tests/test_retention_and_cache.py`, `tests/test_source_contracts.py`, `tests/fixtures/rg.ru/index.xml`)

### Testing

- Ran targeted tests with `python -m pytest tests/test_retention_and_cache.py tests/test_source_contracts.py -q` and they passed. 
- Ran the full test suite with `python -m pytest -q` and all tests passed (`142 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a761c17363c832cbcf4e5d433c68cb2)