### PR TITLE
Harden publication date trust and stable feed sorting

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -104,9 +104,6 @@ HOST_MIN_WORD_OVERRIDES = {
 PUBLICATION_CLOCK_SKEW = timedelta(
     minutes=float(os.environ.get("PUBLICATION_CLOCK_SKEW_MINUTES", "15"))
 )
-PUBLICATION_TIMEZONE_SKEW = timedelta(
-    hours=float(os.environ.get("PUBLICATION_TIMEZONE_SKEW_HOURS", "26"))
-)
 PUBLICATION_REJECTION_SAMPLE_LIMIT = int(
     os.environ.get("PUBLICATION_REJECTION_SAMPLE_LIMIT", "5")
 )
@@ -933,7 +930,7 @@ class PublicationDiagnostics:
                 "url": url,
                 "future_offset_seconds": offset_seconds,
                 "classification": (
-                    "timezone_scale_skew" if offset <= PUBLICATION_TIMEZONE_SKEW
+                    "clock_skew" if offset <= PUBLICATION_CLOCK_SKEW
                     else "clearly_invalid_future_date"
                 ),
             })
@@ -947,7 +944,7 @@ def validate_publication_datetime(
     source: str | None = None,
     signal: str = "unknown",
     now: datetime | None = None,
-    allowance: timedelta = PUBLICATION_TIMEZONE_SKEW,
+    allowance: timedelta = PUBLICATION_CLOCK_SKEW,
     diagnostics: PublicationDiagnostics | None = None,
 ) -> datetime | None:
     """Return a normalized, plausible publication time, or reject it.
@@ -955,8 +952,8 @@ def validate_publication_datetime(
     ``now`` and ``allowance`` are injectable so callers and tests do not need
     to depend on wall-clock time. All extraction paths should pass through
     this single boundary before a value is stored as ``published_at``. The
-    default accommodates timezone-scale metadata errors; signals known not to
-    contain a timezone can opt into the smaller clock-skew allowance.
+    deliberately small default is also used for timezone-aware values:
+    timezone offsets are normalized, not excused with a day-scale allowance.
     """
     dt = finalize_datetime(dt)
     if dt is None:
@@ -1195,17 +1192,35 @@ def ensure_item_metadata(item: dict[str, object]) -> None:
     published_val = item.get("published_at")
     if published_val:
         published_dt = _coerce_msk_datetime(published_val)
+        trustworthy = bool(item.get("_published_at_trustworthy"))
         published_dt = validate_publication_datetime(
             published_dt,
             raw_value=published_val,
             url=str(item.get("url") or ""),
             source=str(item.get("source") or ""),
             signal="stored:published_at",
+            now=fetched_dt,
         )
+        # Old feeds commonly copied crawl time into published_at.  Without
+        # fresh extraction provenance it is not a publication signal.
+        if published_dt and not trustworthy and published_dt >= fetched_dt:
+            published_dt = None
         if published_dt:
             item["published_at"] = published_dt.isoformat()
         else:
             item.pop("published_at", None)
+
+
+def sort_timestamp(item: dict[str, object]) -> str:
+    """Return a stable chronology key which never rewards a later refetch."""
+    published = _coerce_msk_datetime(item.get("published_at"))
+    fetched = _coerce_msk_datetime(item.get("fetched_at"))
+    if published and fetched:
+        published = validate_publication_datetime(published, now=fetched)
+    if published:
+        return published.isoformat()
+    first_seen = _coerce_msk_datetime(item.get("first_seen"))
+    return first_seen.isoformat() if first_seen else ""
 
 
 def _filter_by_min_words(items: list[dict]) -> list[dict]:
@@ -1727,7 +1742,9 @@ def extract_published_datetime(
         seen_candidates.add(key)
         return _parse_datetime_signal(candidate, signal, url=url, source=source, diagnostics=diagnostics)
 
-    # Primary meta tags.
+    # Explicit publication metadata is trustworthy.  Modified/upload dates
+    # are intentionally not fallbacks: they describe page activity, not the
+    # article's original chronology.
     for tag in soup.find_all("meta", attrs={"property": "article:published_time"}):
         dt = attempt(tag.get("content") or tag.get("value"), "meta[property=article:published_time]")
         if dt:
@@ -1738,24 +1755,29 @@ def extract_published_datetime(
         if dt:
             return dt
 
-    for node in soup.find_all(attrs={"itemprop": "datePublished"}):
-        dt = attempt(
-            node.get("content")
-            or node.get("datetime")
-            or node.get_text(" ", strip=True),
-            "[itemprop=datePublished]",
-        )
-        if dt:
-            return dt
+    article_roots = list(soup.select(
+        "article, [itemscope][itemtype*='Article'], [itemtype*='NewsArticle']"
+    ))
+    for root in article_roots:
+        for node in root.find_all(attrs={"itemprop": "datePublished"}):
+            dt = attempt(
+                node.get("content")
+                or node.get("datetime")
+                or node.get_text(" ", strip=True),
+                "[itemprop=datePublished]",
+            )
+            if dt:
+                return dt
 
-    # <time> elements
-    for t in soup.find_all("time"):
+    # Only article-scoped time elements are independent evidence.  Global
+    # time/date widgets are commonly current-dated sidebar or header chrome.
+    for t in (tag for root in article_roots for tag in root.find_all("time")):
         for candidate in (t.get("datetime"), t.get("content"), t.get_text(" ", strip=True)):
             dt = attempt(candidate, "<time>")
             if dt:
                 return dt
 
-    # JSON-LD datePublished/dateCreated.
+    # JSON-LD must identify an Article/NewsArticle object and datePublished.
     for script in soup.find_all("script"):
         script_type = script.get("type") or ""
         if "ld+json" not in script_type.lower():
@@ -1779,18 +1801,27 @@ def extract_published_datetime(
             if not isinstance(node, dict):
                 continue
             types = _json_ld_types(node)
-            if types and not any(t in JSON_LD_ARTICLE_TYPES for t in types):
+            if not types or not any(t in JSON_LD_ARTICLE_TYPES for t in types):
                 continue
-            for key in ("datePublished", "dateCreated", "dateModified", "uploadDate"):
-                raw_val = node.get(key)
-                if isinstance(raw_val, str):
-                    dt = attempt(raw_val, f"json_ld:{key}")
-                    if dt:
-                        return dt
+            raw_val = node.get("datePublished")
+            if isinstance(raw_val, str):
+                dt = attempt(raw_val, "json_ld:datePublished")
+                if dt:
+                    return dt
 
-    # Fallback heuristics.
-    for candidate in extract_date_candidates(soup):
-        dt = attempt(candidate, "heuristic")
+    # A date embedded in the canonical article URL is stable and independent
+    # of page chrome.  Try it even after a suspicious metadata value failed.
+    canonical = extract_canonical_url(soup, url or "") or url or ""
+    match = re.search(r"/(20\d{2})/([01]\d)/([0-3]\d)(?:/|$)", canonical)
+    if match:
+        try:
+            dt = validate_publication_datetime(
+                datetime(*map(int, match.groups())), raw_value=match.group(0),
+                url=url, source=source, signal="canonical_url:path",
+                diagnostics=diagnostics,
+            )
+        except ValueError:
+            dt = None
         if dt:
             return dt
 
@@ -2044,6 +2075,7 @@ def build_item(
     item["_content_source"] = content_source
     if dt:
         item["published_at"] = dt.isoformat()
+        item["_published_at_trustworthy"] = True
     if canonical_url and canonical_url != url:
         item["canonical_url"] = canonical_url
     if amp_used:
@@ -3196,7 +3228,7 @@ def retain_bounded_items(items: list[dict]) -> list[dict]:
         if not queues[source]:
             del queues[source]
     selected.sort(
-        key=lambda x: x.get("published_at") or x.get("fetched_at") or x.get("first_seen") or "",
+        key=sort_timestamp,
         reverse=True,
     )
     return selected
@@ -3225,7 +3257,7 @@ def build_feed(all_items):
 
     items = _filter_by_min_words(list(by_id.values()))
     items.sort(
-        key=lambda x: x.get("published_at") or x.get("fetched_at") or x.get("first_seen") or "",
+        key=sort_timestamp,
         reverse=True,
     )
 
@@ -3275,6 +3307,7 @@ def merge_items(existing, new):
         # Sanitize incoming records before comparing publication times. This
         # prevents a rejected future value from replacing (and then erasing) a
         # plausible date already held by the existing record.
+        incoming_publication_is_trustworthy = bool(it.get("_published_at_trustworthy"))
         it = _finalize_item_schema(dict(it))
         key = it.get("id") or it.get("url")
         if not key:
@@ -3330,11 +3363,13 @@ def merge_items(existing, new):
             elif value not in (None, ""):
                 merged[field] = value
 
+        if incoming_publication_is_trustworthy and it.get("published_at") == merged.get("published_at"):
+            merged["_published_at_trustworthy"] = True
         by_key[key] = _finalize_item_schema(merged)
 
     merged_items = list(by_key.values())
     merged_items.sort(
-        key=lambda x: x.get("published_at") or x.get("fetched_at") or x.get("first_seen") or "",
+        key=sort_timestamp,
         reverse=True,
     )
 

--- a/tests/test_date_extract.py
+++ b/tests/test_date_extract.py
@@ -28,8 +28,7 @@ def fixed_now(monkeypatch):
 
 def test_try_parse_any_date_relative_today(fixed_now):
     result = aggregate.try_parse_any_date(["сегодня 12:45"])
-    assert result is not None
-    assert result.isoformat() == "2024-10-05T12:45:00+03:00"
+    assert result is None
 
 
 def test_try_parse_any_date_relative_yesterday(fixed_now):
@@ -39,7 +38,7 @@ def test_try_parse_any_date_relative_yesterday(fixed_now):
 
 
 def test_extract_published_datetime_time_tag():
-    html = "<html><body><time datetime='2024-10-03T09:15:00+03:00'>03.10.2024</time></body></html>"
+    html = "<html><body><article><time datetime='2024-10-03T09:15:00+03:00'>03.10.2024</time></article></body></html>"
     soup = BeautifulSoup(html, "html.parser")
     dt = aggregate.extract_published_datetime(soup, url="https://example.com/test")
     assert dt is not None
@@ -50,7 +49,7 @@ def test_extract_published_datetime_time_tag():
     ("value", "expected"),
     [
         ("2024-10-05T09:00:00+03:00", "2024-10-05T09:00:00+03:00"),
-        ("2024-10-06T10:00:00+03:00", "2024-10-06T10:00:00+03:00"),
+        ("2024-10-06T10:00:00+03:00", None),
         ("2025-02-05T10:00:00+03:00", None),
     ],
 )
@@ -127,3 +126,32 @@ def test_explicit_publication_diagnostics_are_bounded_and_structured(
         == "2024-10-06T13:00:00+03:00"
     )
     assert summary["maximum_future_offset_seconds"] > 0
+
+
+def test_article_date_wins_over_current_sidebar_date(fixed_now):
+    soup = BeautifulSoup("""
+      <article><time datetime="2020-02-03T09:00:00+03:00">3 февраля 2020</time></article>
+      <aside><div class="date">5 октября 2024</div></aside>
+    """, "html.parser")
+    dt = aggregate.extract_published_datetime(soup, "https://notim.ru/news/story")
+    assert dt.isoformat() == "2020-02-03T09:00:00+03:00"
+
+
+def test_page_chrome_date_is_not_a_publication_date(fixed_now):
+    soup = BeautifulSoup("""
+      <main><h1>Старая новость</h1></main>
+      <aside><time datetime="2024-10-05T09:59:00+03:00">Сегодня</time></aside>
+    """, "html.parser")
+    assert aggregate.extract_published_datetime(
+        soup, "https://gge.ru/press/news/old-story"
+    ) is None
+
+
+def test_rejected_article_metadata_falls_back_to_canonical_url(fixed_now):
+    soup = BeautifulSoup("""
+      <head><meta property="article:published_time" content="2024-10-06T09:00:00+03:00">
+      <link rel="canonical" href="https://example.com/news/2020/02/03/story"></head>
+      <article><p>Story</p></article>
+    """, "html.parser")
+    dt = aggregate.extract_published_datetime(soup, "https://example.com/story")
+    assert dt.isoformat().startswith("2020-02-03T")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -13,6 +13,7 @@ from scripts.aggregate import (
     _filter_by_min_words,
     build_item,
     merge_items,
+    sort_timestamp,
 )
 
 
@@ -202,6 +203,32 @@ class MergeItemsTests(unittest.TestCase):
             ),
             item_a["id"],
         )
+
+    def test_refetch_does_not_promote_old_undated_item(self):
+        old = {
+            "first_seen": "2020-02-03T09:00:00+03:00",
+            "fetched_at": "2026-08-07T18:00:00+03:00",
+        }
+        recent = {
+            "first_seen": "2024-10-05T08:00:00+03:00",
+            "fetched_at": "2024-10-05T08:05:00+03:00",
+        }
+        self.assertLess(sort_timestamp(old), sort_timestamp(recent))
+
+    def test_migrates_crawl_time_masquerading_as_publication(self):
+        timestamp = "2024-10-05T09:00:00+03:00"
+        merged = merge_items([{
+            "id": "legacy",
+            "source": "Example",
+            "title": "Old undated story",
+            "url": "https://example.com/old",
+            "content_text": "content",
+            "first_seen": "2020-02-03T09:00:00+03:00",
+            "bucketed_at": "2020-02-03T09:00:00+03:00",
+            "fetched_at": timestamp,
+            "published_at": timestamp,
+        }], [])
+        self.assertNotIn("published_at", merged[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Publication timestamps are noisy: page chrome, modified/upload times, and legacy feeds can mislead sorting and surface future dates that are implausible relative to crawl time.
- The feed should prefer independent, article-scoped signals and avoid letting refetches or rediscovery promote old undated content.

### Description
- Reworked `extract_published_datetime` to prefer article-scoped signals: JSON-LD `datePublished` on Article/NewsArticle nodes, `itemprop=datePublished` within article roots, `<time>` inside article roots, explicit `meta[property=article:published_time]`, and canonical-URL date paths as a stable fallback, while avoiding global page-chrome and modified/upload dates as overriding signals.
- Tightened future-date validation by replacing the previous large timezone allowance with the small configurable clock skew `PUBLICATION_CLOCK_SKEW` and updated `validate_publication_datetime` to use it for timezone-aware normalization and rejection.
- Hardened stored-item handling in `ensure_item_metadata` so stored `published_at` values are validated relative to the item’s `fetched_at` and dropped when they appear to be crawl timestamps copied into `published_at` unless the extraction provenance marks them trustworthy (`_published_at_trustworthy`).
- Added `sort_timestamp(item)` that prefers a plausible `published_at` and otherwise uses stable `first_seen`, and applied it to feed sorting, retention selection, and merge ordering so refetch/fetch-time cannot promote old articles; also propagate a `_published_at_trustworthy` flag during extraction/merge so trustworthy dates are preserved.
- Extended tests in `tests/test_date_extract.py` and `tests/test_merge.py` to cover article-scoped vs sidebar dates, canonical-url fallback after rejected metadata, timezone-aware future timestamps, migration of legacy crawl-time `published_at` values, and refetch ordering for undated items.

### Testing
- Ran `PYTHONPATH=. pytest -q` which executed the full test suite and reported all tests passing (`147 passed`) with only existing parser warnings. 
- Verified the modified unit tests `tests/test_date_extract.py` and `tests/test_merge.py` exercised the new behaviors and regressions and passed under the same test run. 
- Confirmed no diff-check issues remained after making the changes (local checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7621b2a43c832c924ef64dc0e7d867)