### PR TITLE
Separate crawl health from retained freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,19 @@ fallback и неожиданно пустых index-страницах. Отсу
 
 Строка каждого источника разделяет `retained_item_count` (число карточек в
 ограниченной ленте) и, при передаче `--source-health`, показатели текущего
-обхода `raw_link_candidates` и `accepted_articles`. Источник без сохранённой
-временной метки получает `freshness_status=no_data`, а не считается свежим.
+обхода: `current_crawl_status`, `index_fetch_status`, `raw_link_candidates`,
+`accepted_links`, `attempted_articles` и `accepted_articles`. Отдельно выводятся
+`newest_retained_timestamp` и `retained_content_freshness_status`; источник без
+сохранённой временной метки получает
+`retained_content_freshness_status=no_data`, а не считается свежим. Время
+`last_successful_discovery_at` и `discovery_recency_status` описывают успешное
+обнаружение ссылок независимо от возраста сохранённых карточек. Если для
+источника не задан свой интервал, для discovery recency применяется общий
+`--stale-hours`.
 Проверки можно включить точечно в объекте источника в `sources.json`:
 `expected_min_candidates` задаёт минимум найденных при обходе кандидатов,
-`expected_update_hours` — максимальный возраст последней сохранённой карточки,
+`expected_update_hours` — максимальный возраст последнего успешного обнаружения
+при наличии `--source-health` (без него — возраст последней сохранённой карточки),
 а `allow_empty: false` включает проверку отсутствия карточек только для этого
 источника. Флаг `--fail-on-empty-source` включает такую проверку глобально;
 `allow_empty: true` или одноимённый аргумент со значением имени источника

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -140,6 +140,7 @@ def merge_current_crawl_metrics(
     source_report: list[dict[str, Any]],
     health_rows: list[dict[str, Any]],
     *,
+    stale_after: timedelta = timedelta(days=7),
     now: datetime | None = None,
 ) -> None:
     """Attach current-run health without deriving it from retained feed items."""
@@ -191,17 +192,15 @@ def merge_current_crawl_metrics(
 
         discovery = _parse_timestamp(row["last_successful_discovery_at"])
         expected_hours = row.get("expected_update_hours")
-        window = (
+        discovery_window = (
             timedelta(hours=max(0, float(expected_hours)))
             if expected_hours is not None
-            else None
+            else stale_after
         )
         row["discovery_recency_status"] = (
             "no_data"
             if discovery is None
-            else (
-                "stale" if window is not None and discovery < now - window else "recent"
-            )
+            else ("stale" if discovery < now - discovery_window else "recent")
         )
 
 
@@ -439,7 +438,11 @@ def main() -> int:
         if not health_path.exists():
             raise SystemExit(f"Source health file not found: {health_path}")
         health_rows = _load_source_health(health_path)
-        merge_current_crawl_metrics(source_report, health_rows)
+        merge_current_crawl_metrics(
+            source_report,
+            health_rows,
+            stale_after=timedelta(hours=max(0, args.stale_hours)),
+        )
 
     for row in source_report:
         newest = row["newest_retained_timestamp"] or "none"

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -83,19 +83,17 @@ def compute_source_metrics(
         freshness_window = stale_after
         if expected_update_hours is not None:
             freshness_window = timedelta(hours=max(0, float(expected_update_hours)))
-        freshness_status = (
+        retained_freshness_status = (
             "no_data"
             if newest is None
-            else "stale"
-            if newest < now - freshness_window
-            else "fresh"
+            else "stale" if newest < now - freshness_window else "fresh"
         )
         report.append(
             {
                 "source": name,
                 "retained_item_count": len(source_items),
-                "newest_timestamp": newest.isoformat() if newest else None,
-                "freshness_status": freshness_status,
+                "newest_retained_timestamp": newest.isoformat() if newest else None,
+                "retained_content_freshness_status": retained_freshness_status,
                 "expected_min_candidates": source.get("expected_min_candidates"),
                 "expected_update_hours": expected_update_hours,
                 # Bounded feeds are allowed to omit a source unless its
@@ -109,9 +107,11 @@ def compute_source_metrics(
         "enabled_sources": len(report),
         "sources_with_items": sum(row["retained_item_count"] > 0 for row in report),
         "sources_without_items": sum(row["retained_item_count"] == 0 for row in report),
-        "stale_sources": sum(row["freshness_status"] == "stale" for row in report),
+        "stale_sources": sum(
+            row["retained_content_freshness_status"] == "stale" for row in report
+        ),
         "sources_without_freshness_data": sum(
-            row["freshness_status"] == "no_data" for row in report
+            row["retained_content_freshness_status"] == "no_data" for row in report
         ),
     }
     return totals, report
@@ -137,17 +137,71 @@ def find_unexpected_empty_sources(
 
 
 def merge_current_crawl_metrics(
-    source_report: list[dict[str, Any]], health_rows: list[dict[str, Any]]
+    source_report: list[dict[str, Any]],
+    health_rows: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
 ) -> None:
-    """Attach current-run discovery and acceptance counts to retained rows."""
+    """Attach current-run health without deriving it from retained feed items."""
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     health_by_source = {str(row.get("source", "")): row for row in health_rows}
     for row in source_report:
         health = health_by_source.get(str(row["source"]))
-        row["raw_link_candidates"] = (
-            int(health.get("raw_link_candidates") or 0) if health is not None else None
+        count_fields = (
+            "raw_link_candidates",
+            "accepted_links",
+            "attempted_articles",
+            "accepted_articles",
+            "consecutive_fetch_failures",
+            "consecutive_discovery_failures",
+            "consecutive_article_failures",
         )
-        row["accepted_articles"] = (
-            int(health.get("accepted_articles") or 0) if health is not None else None
+        for field in count_fields:
+            row[field] = int(health.get(field) or 0) if health is not None else None
+        row["index_fetch_status"] = health.get("index_fetch_status") if health else None
+        row["last_successful_discovery_at"] = (
+            health.get("last_successful_discovery_at") if health else None
+        )
+        row["cached_fallback_used"] = (
+            bool(health.get("cached_fallback_used")) if health else None
+        )
+
+        status = (
+            str(health.get("index_fetch_status") or "not_attempted")
+            if health
+            else "not_attempted"
+        )
+        if status in {"not_attempted", "skipped_selection"}:
+            crawl_status = "not_attempted"
+        elif status in {"failed", "parser_error"}:
+            crawl_status = "failed"
+        elif (
+            status == "cached"
+            or bool(health.get("cached_fallback_used"))
+            or any(int(health.get(field) or 0) for field in count_fields[4:])
+            or (
+                int(health.get("attempted_articles") or 0) > 0
+                and int(health.get("accepted_articles") or 0) == 0
+            )
+        ):
+            crawl_status = "degraded"
+        else:
+            crawl_status = "healthy"
+        row["current_crawl_status"] = crawl_status
+
+        discovery = _parse_timestamp(row["last_successful_discovery_at"])
+        expected_hours = row.get("expected_update_hours")
+        window = (
+            timedelta(hours=max(0, float(expected_hours)))
+            if expected_hours is not None
+            else None
+        )
+        row["discovery_recency_status"] = (
+            "no_data"
+            if discovery is None
+            else (
+                "stale" if window is not None and discovery < now - window else "recent"
+            )
         )
 
 
@@ -167,9 +221,27 @@ def find_source_expectation_failures(source_report: list[dict[str, Any]]) -> lis
                 failures.append(
                     f"{name}: discovered {discovered} candidates, expected at least {int(minimum)}"
                 )
-        if row.get("expected_update_hours") is not None and row["freshness_status"] != "fresh":
+        if row.get("expected_update_hours") is not None:
+            # Once crawl health is merged, update expectations concern discovery
+            # activity. Retained content age remains an independent diagnostic.
+            status_key = (
+                "discovery_recency_status"
+                if "discovery_recency_status" in row
+                else "retained_content_freshness_status"
+            )
+            recency = row[status_key]
+            satisfactory = (
+                "recent" if status_key == "discovery_recency_status" else "fresh"
+            )
+            if recency == satisfactory:
+                continue
+            subject = (
+                "discovery recency"
+                if status_key == "discovery_recency_status"
+                else "retained content freshness"
+            )
             failures.append(
-                f"{name}: freshness is {row['freshness_status']}, expected an update within "
+                f"{name}: {subject} is {recency}, expected an update within "
                 f"{row['expected_update_hours']} hours"
             )
     return failures
@@ -202,7 +274,9 @@ def classify_source_health(
         legacy_streak = int(row.get("consecutive_failures") or 0)
         fetch_streak = int(row.get("consecutive_fetch_failures", legacy_streak) or 0)
         discovery_streak = int(row.get("consecutive_discovery_failures") or 0)
-        article_streak = int(row.get("consecutive_article_failures", legacy_streak) or 0)
+        article_streak = int(
+            row.get("consecutive_article_failures", legacy_streak) or 0
+        )
         attempted = int(row.get("attempted_articles") or 0)
         accepted = int(row.get("accepted_articles") or 0)
         raw_candidates = int(row.get("raw_link_candidates") or 0)
@@ -215,7 +289,9 @@ def classify_source_health(
             continue
         elif hard_status and fetch_streak >= failure_threshold:
             detail = f" ({error})" if error else ""
-            failures.append(f"{name}: {status} for {fetch_streak} consecutive runs{detail}")
+            failures.append(
+                f"{name}: {status} for {fetch_streak} consecutive runs{detail}"
+            )
         elif hard_status:
             warnings.append(
                 f"{name}: transient {status} (run {fetch_streak}/{failure_threshold})"
@@ -229,31 +305,35 @@ def classify_source_health(
             if discovery_streak >= failure_threshold:
                 failures.append(message)
             else:
-                warnings.append(f"{name}: transient discovery failure (run {discovery_streak}/{failure_threshold}; {detail})")
+                warnings.append(
+                    f"{name}: transient discovery failure (run {discovery_streak}/{failure_threshold}; {detail})"
+                )
         elif article_outage and article_streak >= failure_threshold:
             detail = f" ({error})" if error else ""
-            failures.append(f"{name}: {failure_kind} for {article_streak} consecutive runs{detail}")
+            failures.append(
+                f"{name}: {failure_kind} for {article_streak} consecutive runs{detail}"
+            )
         elif article_outage and article_streak:
             warnings.append(
                 f"{name}: transient {failure_kind} (run {article_streak}/{failure_threshold})"
             )
         elif status == "cached" or row.get("cached_fallback_used"):
             warnings.append(f"{name}: cached fallback used")
-        elif (
-            status == "fetched"
-            and attempted == 0
-            and raw_candidates == 0
-        ):
+        elif status == "fetched" and attempted == 0 and raw_candidates == 0:
             warnings.append(f"{name}: fetched index contained no link candidates")
         elif attempted > 0 and accepted == 0:
             warnings.append(f"{name}: attempted {attempted} articles but accepted none")
         future_rejections = int(row.get("future_date_rejections") or 0)
         if future_rejections:
-            warnings.append(f"{name}: rejected {future_rejections} future publication dates")
+            warnings.append(
+                f"{name}: rejected {future_rejections} future publication dates"
+            )
     return failures, warnings
 
 
-def check_anti_genie(baseline: dict[str, int], current: dict[str, int]) -> Tuple[bool, str | None]:
+def check_anti_genie(
+    baseline: dict[str, int], current: dict[str, int]
+) -> Tuple[bool, str | None]:
     """Ensure totals do not shrink except for removed listings."""
 
     allowed_min_total = baseline["total"] - baseline["listing_urls_count"]
@@ -268,37 +348,70 @@ def check_anti_genie(baseline: dict[str, int], current: dict[str, int]) -> Tuple
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Compute quick feed metrics")
-    parser.add_argument("path", nargs="?", default="docs/unified.json", help="Path to unified feed JSON")
-    parser.add_argument("--sources", default="sources.json", help="Path to source configuration JSON")
-    parser.add_argument("--stale-hours", type=float, default=168, help="Age in hours after which a source is stale")
     parser.add_argument(
-        "--allow-empty", action="append", default=[], metavar="SOURCE",
+        "path", nargs="?", default="docs/unified.json", help="Path to unified feed JSON"
+    )
+    parser.add_argument(
+        "--sources", default="sources.json", help="Path to source configuration JSON"
+    )
+    parser.add_argument(
+        "--stale-hours",
+        type=float,
+        default=168,
+        help="Age in hours after which a source is stale",
+    )
+    parser.add_argument(
+        "--allow-empty",
+        action="append",
+        default=[],
+        metavar="SOURCE",
         help="Source exempted from empty-source enforcement (repeat or comma-separated)",
     )
     parser.add_argument(
-        "--fail-on-empty-source", action="store_true",
+        "--fail-on-empty-source",
+        action="store_true",
         help="Globally fail when a non-exempt enabled source has no retained feed items",
     )
     parser.add_argument(
-        "--source-health", metavar="PATH",
+        "--source-health",
+        metavar="PATH",
         help="Crawl diagnostics JSON produced by aggregate.py",
     )
     parser.add_argument(
-        "--strict-source-health", action="store_true",
+        "--strict-source-health",
+        action="store_true",
         help="Fail on repeated crawl failures reported by --source-health",
     )
     parser.add_argument(
-        "--failure-threshold", type=int, default=3,
+        "--failure-threshold",
+        type=int,
+        default=3,
         help="Consecutive failed crawls required for a hard source-health failure (default: 3)",
     )
     parser.add_argument(
         "--baseline",
         help="Optional baseline feed JSON to enforce anti-genie rule (total can't drop except filtered listings)",
     )
-    parser.add_argument("--promote-feed", metavar="PATH", help="Replace this published feed only after every check passes")
-    parser.add_argument("--promote-source-health", metavar="PATH", help="Replace this published health report only after every check passes")
-    parser.add_argument("--candidate-state", metavar="PATH", help="Candidate crawler state to promote after validation")
-    parser.add_argument("--promote-state", metavar="PATH", help="Published crawler state replaced after validation")
+    parser.add_argument(
+        "--promote-feed",
+        metavar="PATH",
+        help="Replace this published feed only after every check passes",
+    )
+    parser.add_argument(
+        "--promote-source-health",
+        metavar="PATH",
+        help="Replace this published health report only after every check passes",
+    )
+    parser.add_argument(
+        "--candidate-state",
+        metavar="PATH",
+        help="Candidate crawler state to promote after validation",
+    )
+    parser.add_argument(
+        "--promote-state",
+        metavar="PATH",
+        help="Published crawler state replaced after validation",
+    )
     args = parser.parse_args()
 
     path = pathlib.Path(args.path)
@@ -329,18 +442,28 @@ def main() -> int:
         merge_current_crawl_metrics(source_report, health_rows)
 
     for row in source_report:
-        newest = row["newest_timestamp"] or "none"
+        newest = row["newest_retained_timestamp"] or "none"
         fields = [
             f"source: {row['source']}",
             f"retained_item_count={row['retained_item_count']}",
-            f"newest={newest}",
-            f"freshness_status={row['freshness_status']}",
+            f"newest_retained_timestamp={newest}",
+            f"retained_content_freshness_status={row['retained_content_freshness_status']}",
         ]
         if args.source_health:
             fields.extend(
                 [
+                    f"current_crawl_status={row['current_crawl_status']}",
+                    f"index_fetch_status={row['index_fetch_status']}",
                     f"raw_link_candidates={row['raw_link_candidates']}",
+                    f"accepted_links={row['accepted_links']}",
+                    f"attempted_articles={row['attempted_articles']}",
                     f"accepted_articles={row['accepted_articles']}",
+                    f"consecutive_fetch_failures={row['consecutive_fetch_failures']}",
+                    f"consecutive_discovery_failures={row['consecutive_discovery_failures']}",
+                    f"consecutive_article_failures={row['consecutive_article_failures']}",
+                    f"last_successful_discovery_at={row['last_successful_discovery_at'] or 'none'}",
+                    f"discovery_recency_status={row['discovery_recency_status']}",
+                    f"cached_fallback_used={row['cached_fallback_used']}",
                 ]
             )
         print(" | ".join(fields))
@@ -349,7 +472,10 @@ def main() -> int:
 
     exit_code = 0
     allow_empty = {
-        name.strip() for value in args.allow_empty for name in value.split(",") if name.strip()
+        name.strip()
+        for value in args.allow_empty
+        for name in value.split(",")
+        if name.strip()
     }
     unexpected_empty = find_unexpected_empty_sources(
         source_report, allow_empty, fail_on_all=args.fail_on_empty_source
@@ -390,7 +516,14 @@ def main() -> int:
             exit_code = 1
 
     if exit_code == 0 and args.promote_feed:
-        if not all((args.source_health, args.promote_source_health, args.candidate_state, args.promote_state)):
+        if not all(
+            (
+                args.source_health,
+                args.promote_source_health,
+                args.candidate_state,
+                args.promote_state,
+            )
+        ):
             parser.error(
                 "promotion requires --source-health, --promote-source-health, "
                 "--candidate-state, and --promote-state"

--- a/tests/test_metrics_tool.py
+++ b/tests/test_metrics_tool.py
@@ -62,39 +62,58 @@ SOURCES = [
 
 
 def test_bounded_feed_emptiness_is_allowed_by_default():
-    _, report = compute_source_metrics([], SOURCES, stale_after=timedelta(days=7), now=NOW)
+    _, report = compute_source_metrics(
+        [], SOURCES, stale_after=timedelta(days=7), now=NOW
+    )
     assert find_unexpected_empty_sources(report, set()) == []
 
 
 def test_global_empty_check_includes_sources_without_per_source_setting():
-    _, report = compute_source_metrics([], SOURCES, stale_after=timedelta(days=7), now=NOW)
+    _, report = compute_source_metrics(
+        [], SOURCES, stale_after=timedelta(days=7), now=NOW
+    )
     assert find_unexpected_empty_sources(report, set(), fail_on_all=True) == [
-        "healthy", "missing"
+        "healthy",
+        "missing",
     ]
 
 
 def test_explicit_allow_empty_exempts_source_from_global_check():
     sources = [{"name": "optional", "allow_empty": True}]
-    _, report = compute_source_metrics([], sources, stale_after=timedelta(days=7), now=NOW)
+    _, report = compute_source_metrics(
+        [], sources, stale_after=timedelta(days=7), now=NOW
+    )
     assert find_unexpected_empty_sources(report, set(), fail_on_all=True) == []
 
 
 def test_source_can_require_a_retained_item():
     sources = [{"name": "required", "allow_empty": False}]
-    _, report = compute_source_metrics([], sources, stale_after=timedelta(days=7), now=NOW)
+    _, report = compute_source_metrics(
+        [], sources, stale_after=timedelta(days=7), now=NOW
+    )
     assert find_unexpected_empty_sources(report, set()) == ["required"]
 
 
 def test_stale_source_is_reported():
     items = [{"source": "healthy", "published_at": "2026-07-01T00:00:00Z"}]
-    totals, report = compute_source_metrics(items, SOURCES, stale_after=timedelta(days=7), now=NOW)
+    totals, report = compute_source_metrics(
+        items, SOURCES, stale_after=timedelta(days=7), now=NOW
+    )
     assert totals["stale_sources"] == 1
-    assert report[0]["freshness_status"] == "stale"
+    assert report[0]["retained_content_freshness_status"] == "stale"
 
 
 def test_healthy_source_uses_fetch_timestamp_when_publication_is_invalid():
-    items = [{"source": "healthy", "published_at": "not-a-date", "fetched_at": "2026-08-05T00:00:00Z"}]
-    totals, report = compute_source_metrics(items, SOURCES, stale_after=timedelta(days=7), now=NOW)
+    items = [
+        {
+            "source": "healthy",
+            "published_at": "not-a-date",
+            "fetched_at": "2026-08-05T00:00:00Z",
+        }
+    ]
+    totals, report = compute_source_metrics(
+        items, SOURCES, stale_after=timedelta(days=7), now=NOW
+    )
     assert totals == {
         "enabled_sources": 2,
         "sources_with_items": 1,
@@ -102,48 +121,67 @@ def test_healthy_source_uses_fetch_timestamp_when_publication_is_invalid():
         "stale_sources": 0,
         "sources_without_freshness_data": 1,
     }
-    assert report[0]["newest_timestamp"] == "2026-08-05T00:00:00+00:00"
+    assert report[0]["newest_retained_timestamp"] == "2026-08-05T00:00:00+00:00"
 
 
 def test_source_without_timestamp_reports_no_data_instead_of_not_stale():
-    _, report = compute_source_metrics([], SOURCES, stale_after=timedelta(days=7), now=NOW)
-    assert report[0]["freshness_status"] == "no_data"
+    _, report = compute_source_metrics(
+        [], SOURCES, stale_after=timedelta(days=7), now=NOW
+    )
+    assert report[0]["retained_content_freshness_status"] == "no_data"
 
 
 def test_explicitly_exempted_empty_source_passes():
     _, report = compute_source_metrics(
-        [], [{"name": "expected empty", "allow_empty": False}],
-        stale_after=timedelta(days=7), now=NOW
+        [],
+        [{"name": "expected empty", "allow_empty": False}],
+        stale_after=timedelta(days=7),
+        now=NOW,
     )
     assert find_unexpected_empty_sources(report, {"expected empty"}) == []
 
 
 def test_current_crawl_counts_and_source_expectations_are_combined():
-    sources = [{
-        "name": "active",
-        "expected_min_candidates": 3,
-        "expected_update_hours": 24,
-    }]
+    sources = [
+        {
+            "name": "active",
+            "expected_min_candidates": 3,
+            "expected_update_hours": 24,
+        }
+    ]
     items = [{"source": "active", "published_at": "2026-08-04T23:59:00Z"}]
     _, report = compute_source_metrics(
         items, sources, stale_after=timedelta(days=7), now=NOW
     )
-    merge_current_crawl_metrics(report, [{
-        "source": "active", "raw_link_candidates": 2, "accepted_articles": 1
-    }])
+    merge_current_crawl_metrics(
+        report,
+        [
+            {
+                "source": "active",
+                "index_fetch_status": "fetched",
+                "raw_link_candidates": 2,
+                "accepted_links": 2,
+                "accepted_articles": 1,
+                "last_successful_discovery_at": "2026-08-04T23:59:00Z",
+            }
+        ],
+        now=NOW,
+    )
 
     assert report[0]["retained_item_count"] == 1
     assert report[0]["raw_link_candidates"] == 2
     assert report[0]["accepted_articles"] == 1
     assert find_source_expectation_failures(report) == [
         "active: discovered 2 candidates, expected at least 3",
-        "active: freshness is stale, expected an update within 24 hours",
+        "active: discovery recency is stale, expected an update within 24 hours",
     ]
 
 
 def test_candidate_expectation_requires_a_current_crawl_row():
     sources = [{"name": "missing crawl", "expected_min_candidates": 1}]
-    _, report = compute_source_metrics([], sources, stale_after=timedelta(days=7), now=NOW)
+    _, report = compute_source_metrics(
+        [], sources, stale_after=timedelta(days=7), now=NOW
+    )
     merge_current_crawl_metrics(report, [])
     assert find_source_expectation_failures(report) == [
         "missing crawl: no current-crawl candidate count, expected at least 1"
@@ -151,12 +189,27 @@ def test_candidate_expectation_requires_a_current_crawl_row():
 
 
 def test_source_health_distinguishes_failures_from_degraded_sources():
-    failures, warnings = classify_source_health([
-        {"source": "broken", "index_fetch_status": "failed", "consecutive_failures": 3, "last_error": "timeout"},
-        {"source": "cached", "index_fetch_status": "cached", "cached_fallback_used": True},
-        {"source": "changed markup", "index_fetch_status": "fetched", "raw_link_candidates": 0},
-        {"source": "good", "index_fetch_status": "unchanged"},
-    ])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "broken",
+                "index_fetch_status": "failed",
+                "consecutive_failures": 3,
+                "last_error": "timeout",
+            },
+            {
+                "source": "cached",
+                "index_fetch_status": "cached",
+                "cached_fallback_used": True,
+            },
+            {
+                "source": "changed markup",
+                "index_fetch_status": "fetched",
+                "raw_link_candidates": 0,
+            },
+            {"source": "good", "index_fetch_status": "unchanged"},
+        ]
+    )
 
     assert failures == ["broken: failed for 3 consecutive runs (timeout)"]
     assert warnings == [
@@ -166,14 +219,16 @@ def test_source_health_distinguishes_failures_from_degraded_sources():
 
 
 def test_source_health_warns_before_failure_threshold_and_counts_bad_dates():
-    failures, warnings = classify_source_health([
-        {
-            "source": "flaky",
-            "index_fetch_status": "failed",
-            "consecutive_failures": 2,
-            "future_date_rejections": 4,
-        }
-    ])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "flaky",
+                "index_fetch_status": "failed",
+                "consecutive_failures": 2,
+                "future_date_rejections": 4,
+            }
+        ]
+    )
 
     assert failures == []
     assert warnings == [
@@ -183,23 +238,25 @@ def test_source_health_warns_before_failure_threshold_and_counts_bad_dates():
 
 
 def test_article_crawl_outage_uses_failure_streak():
-    failures, warnings = classify_source_health([
-        {
-            "source": "articles broken",
-            "index_fetch_status": "fetched",
-            "attempted_articles": 5,
-            "accepted_articles": 0,
-            "last_error": "article timeout",
-            "consecutive_failures": 3,
-        },
-        {
-            "source": "content rejected",
-            "index_fetch_status": "fetched",
-            "attempted_articles": 4,
-            "accepted_articles": 0,
-            "consecutive_failures": 0,
-        },
-    ])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "articles broken",
+                "index_fetch_status": "fetched",
+                "attempted_articles": 5,
+                "accepted_articles": 0,
+                "last_error": "article timeout",
+                "consecutive_failures": 3,
+            },
+            {
+                "source": "content rejected",
+                "index_fetch_status": "fetched",
+                "attempted_articles": 4,
+                "accepted_articles": 0,
+                "consecutive_failures": 0,
+            },
+        ]
+    )
 
     assert failures == [
         "articles broken: article crawl failed for 3 consecutive runs (article timeout)"
@@ -208,27 +265,33 @@ def test_article_crawl_outage_uses_failure_streak():
 
 
 def test_sources_skipped_by_selection_are_ignored():
-    failures, warnings = classify_source_health([
-        {
-            "source": "not selected",
-            "index_fetch_status": "skipped_selection",
-            "consecutive_failures": 99,
-        }
-    ])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "not selected",
+                "index_fetch_status": "skipped_selection",
+                "consecutive_failures": 99,
+            }
+        ]
+    )
 
     assert failures == []
     assert warnings == []
 
 
 def test_repeated_zero_raw_links_becomes_discovery_failure():
-    failures, warnings = classify_source_health([{
-        "source": "empty index",
-        "index_fetch_status": "fetched",
-        "consecutive_discovery_failures": 3,
-        "raw_link_candidates": 0,
-        "accepted_links": 0,
-        "last_successful_discovery_at": "2026-08-06T12:00:00+00:00",
-    }])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "empty index",
+                "index_fetch_status": "fetched",
+                "consecutive_discovery_failures": 3,
+                "raw_link_candidates": 0,
+                "accepted_links": 0,
+                "last_successful_discovery_at": "2026-08-06T12:00:00+00:00",
+            }
+        ]
+    )
 
     assert warnings == []
     assert failures == [
@@ -238,14 +301,18 @@ def test_repeated_zero_raw_links_becomes_discovery_failure():
 
 
 def test_single_zero_accepted_links_is_discovery_warning():
-    failures, warnings = classify_source_health([{
-        "source": "filtered index",
-        "index_fetch_status": "fetched",
-        "consecutive_discovery_failures": 1,
-        "raw_link_candidates": 14,
-        "accepted_links": 0,
-        "last_successful_discovery_at": "2026-08-07T08:30:00+00:00",
-    }])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "filtered index",
+                "index_fetch_status": "fetched",
+                "consecutive_discovery_failures": 1,
+                "raw_link_candidates": 14,
+                "accepted_links": 0,
+                "last_successful_discovery_at": "2026-08-07T08:30:00+00:00",
+            }
+        ]
+    )
 
     assert failures == []
     assert warnings == [
@@ -255,17 +322,96 @@ def test_single_zero_accepted_links_is_discovery_warning():
 
 
 def test_repeated_unchanged_empty_index_becomes_discovery_failure():
-    failures, warnings = classify_source_health([{
-        "source": "unchanged empty",
-        "index_fetch_status": "unchanged",
-        "consecutive_discovery_failures": 4,
-        "raw_link_candidates": 0,
-        "accepted_links": 0,
-        "last_successful_discovery_at": "2026-08-01T00:00:00+00:00",
-    }])
+    failures, warnings = classify_source_health(
+        [
+            {
+                "source": "unchanged empty",
+                "index_fetch_status": "unchanged",
+                "consecutive_discovery_failures": 4,
+                "raw_link_candidates": 0,
+                "accepted_links": 0,
+                "last_successful_discovery_at": "2026-08-01T00:00:00+00:00",
+            }
+        ]
+    )
 
     assert warnings == []
     assert failures == [
         "unchanged empty: discovery failed for 4 consecutive runs (raw candidates=0, "
         "accepted links=0, last successful discovery=2026-08-01T00:00:00+00:00)"
     ]
+
+
+def _merged_report(item_timestamp, health):
+    items = (
+        [{"source": "source", "published_at": item_timestamp}] if item_timestamp else []
+    )
+    _, report = compute_source_metrics(
+        items,
+        [{"name": "source", "expected_update_hours": 24}],
+        stale_after=timedelta(days=7),
+        now=NOW,
+    )
+    merge_current_crawl_metrics(report, [{"source": "source", **health}], now=NOW)
+    return report[0]
+
+
+def test_failed_crawl_is_independent_of_future_dated_retained_item():
+    row = _merged_report(
+        "2027-01-01T00:00:00Z",
+        {
+            "index_fetch_status": "failed",
+            "consecutive_fetch_failures": 1,
+            "last_successful_discovery_at": "2026-08-01T00:00:00Z",
+        },
+    )
+    assert row["current_crawl_status"] == "failed"
+    assert row["retained_content_freshness_status"] == "fresh"
+    assert row["newest_retained_timestamp"] == "2027-01-01T00:00:00+00:00"
+    assert row["discovery_recency_status"] == "stale"
+
+
+def test_failed_crawl_is_prominent_despite_recent_retained_content():
+    row = _merged_report(
+        "2026-08-05T12:00:00Z",
+        {
+            "index_fetch_status": "parser_error",
+            "last_successful_discovery_at": "2026-08-05T12:00:00Z",
+        },
+    )
+    assert row["current_crawl_status"] == "failed"
+    assert row["retained_content_freshness_status"] == "fresh"
+    assert row["discovery_recency_status"] == "recent"
+
+
+def test_successful_discovery_without_new_article_is_healthy():
+    row = _merged_report(
+        None,
+        {
+            "index_fetch_status": "fetched",
+            "raw_link_candidates": 12,
+            "accepted_links": 4,
+            "attempted_articles": 0,
+            "accepted_articles": 0,
+            "last_successful_discovery_at": "2026-08-06T00:00:00Z",
+        },
+    )
+    assert row["current_crawl_status"] == "healthy"
+    assert row["retained_content_freshness_status"] == "no_data"
+    assert row["discovery_recency_status"] == "recent"
+    assert find_source_expectation_failures([row]) == []
+
+
+def test_cached_fallback_is_degraded_but_retained_content_can_be_fresh():
+    row = _merged_report(
+        "2026-08-06T00:00:00Z",
+        {
+            "index_fetch_status": "cached",
+            "cached_fallback_used": True,
+            "accepted_links": 3,
+            "last_successful_discovery_at": "2026-08-06T00:00:00Z",
+        },
+    )
+    assert row["current_crawl_status"] == "degraded"
+    assert row["cached_fallback_used"] is True
+    assert row["retained_content_freshness_status"] == "fresh"

--- a/tests/test_metrics_tool.py
+++ b/tests/test_metrics_tool.py
@@ -415,3 +415,24 @@ def test_cached_fallback_is_degraded_but_retained_content_can_be_fresh():
     assert row["current_crawl_status"] == "degraded"
     assert row["cached_fallback_used"] is True
     assert row["retained_content_freshness_status"] == "fresh"
+
+
+def test_discovery_recency_uses_global_stale_window_when_not_configured():
+    _, report = compute_source_metrics(
+        [], [{"name": "source"}], stale_after=timedelta(days=30), now=NOW
+    )
+    merge_current_crawl_metrics(
+        report,
+        [
+            {
+                "source": "source",
+                "index_fetch_status": "unchanged",
+                "last_successful_discovery_at": "2026-07-20T00:00:00Z",
+            }
+        ],
+        stale_after=timedelta(days=7),
+        now=NOW,
+    )
+
+    assert report[0]["current_crawl_status"] == "healthy"
+    assert report[0]["discovery_recency_status"] == "stale"


### PR DESCRIPTION
### Motivation

- Make retained-item freshness semantics explicit by renaming the retained-item metrics and keeping them independent from current crawl diagnostics.
- Surface crawl diagnostics from `docs/source-health.json` so current-run failures, cached fallbacks, and discovery recency are visible alongside retained feed metrics.
- Ensure expectations about discovery activity use current crawl recency instead of being influenced by aged or future-dated retained items.

### Description

- Rename retained-feed fields in `compute_source_metrics` to `newest_retained_timestamp` and `retained_content_freshness_status` and keep retained freshness computation unchanged. 
- Enhance `merge_current_crawl_metrics` to attach `index_fetch_status`, `last_successful_discovery_at`, `raw_link_candidates`, `accepted_links`, `attempted_articles`, `accepted_articles`, consecutive failure counts (`consecutive_fetch_failures`, `consecutive_discovery_failures`, `consecutive_article_failures`), and `cached_fallback_used`, and derive a per-row `current_crawl_status` with values like `healthy`, `degraded`, `failed`, or `not_attempted` that are computed strictly from the source-health row. 
- Compute `discovery_recency_status` from `last_successful_discovery_at` and `expected_update_hours` so discovery recency is reported separately from retained-content freshness, and update `find_source_expectation_failures` to prefer discovery recency when source-health is present while leaving retained freshness independent. 
- Update CLI reporting in `main()` to expose `current_crawl_status`, `index_fetch_status`, `accepted_links`, `attempted_articles`, consecutive failure counts, `last_successful_discovery_at`, `discovery_recency_status`, and `cached_fallback_used` alongside retained-content fields. 
- Add unit tests in `tests/test_metrics_tool.py` that cover: a failed crawl with a future-dated retained item, a failed crawl with genuinely recent retained content, successful discovery with no newly accepted article, and cached fallback usage; plus small test updates to reflect renamed retained fields.

### Testing

- Ran the metrics unit tests with `PYTHONPATH=. pytest -q tests/test_metrics_tool.py`, and the file-level tests passed. 
- Ran the full test suite with `PYTHONPATH=. pytest -q`, and all tests passed (151 passed, with three existing XML-parser warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7627f49e18832ca3df62a07e4730be)