### PR TITLE
Improve index failure diagnostics

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -3130,6 +3130,7 @@ def write_source_health_report(sources: list[dict]) -> None:
     # succeeded.
     legacy_streaks = SOURCE_HEALTH_STATE
     fetch_streaks = STATE.setdefault("source_fetch_failure_streaks", {})
+    parser_streaks = STATE.setdefault("source_parser_failure_streaks", {})
     discovery_streaks = STATE.setdefault("source_discovery_failure_streaks", {})
     article_streaks = STATE.setdefault("source_article_failure_streaks", {})
     discovery_state = STATE.setdefault("source_discovery_state", {})
@@ -3188,6 +3189,7 @@ def write_source_health_report(sources: list[dict]) -> None:
 
         if status != "skipped_selection":
             fetch_streak = update_streak(fetch_streaks, fetch_failed)
+            parser_streak = update_streak(parser_streaks, parser_failed)
             discovery_streak = update_streak(discovery_streaks, discovery_failed)
             article_streak = update_streak(article_streaks, article_failed)
             previous_legacy = int(legacy_streaks.get(name, 0) or 0)
@@ -3195,6 +3197,7 @@ def write_source_health_report(sources: list[dict]) -> None:
             legacy_streaks[name] = previous_legacy + 1 if any_failure else 0
         else:
             fetch_streak = int(fetch_streaks.get(name, 0) or 0)
+            parser_streak = int(parser_streaks.get(name, 0) or 0)
             discovery_streak = int(discovery_streaks.get(name, 0) or 0)
             article_streak = int(article_streaks.get(name, 0) or 0)
             legacy_streaks.setdefault(name, int(legacy_streaks.get(name, 0) or 0))
@@ -3204,6 +3207,7 @@ def write_source_health_report(sources: list[dict]) -> None:
             "failure_class": failure_class,
             "consecutive_failures": legacy_streaks[name],
             "consecutive_fetch_failures": fetch_streak,
+            "consecutive_parser_failures": parser_streak,
             "consecutive_discovery_failures": discovery_streak,
             "consecutive_article_failures": article_streak,
             "raw_link_candidates": raw_candidates,

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when run as a script
 try:
     from scripts.http_client import (
         HostClient,
+        CrawlerParserError,
         RequestStrategy,
         SourceTemporarilyUnavailable,
         build_strategy_registry,
@@ -31,6 +32,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - fallback when run as a script
     from http_client import (  # type: ignore
         HostClient,
+        CrawlerParserError,
         RequestStrategy,
         SourceTemporarilyUnavailable,
         build_strategy_registry,
@@ -728,6 +730,8 @@ def fetch_page(url: str, src: dict | None = None) -> str:
         client = get_host_client(url, src)
         if client and client.strategy.selenium_fallback:
             selenium_html = client.fetch_html_with_selenium(url)
+            if selenium_html is not None and not isinstance(selenium_html, str):
+                raise CrawlerParserError("fetch_page.selenium_fallback", url, selenium_html)
             if selenium_html:
                 content = selenium_html
             else:
@@ -753,6 +757,8 @@ def fetch_page(url: str, src: dict | None = None) -> str:
             headers={"User-Agent": USER_AGENT},
             timeout=REQUEST_TIMEOUT,
         ).text
+    if not isinstance(content, str) or not content.strip():
+        raise CrawlerParserError("fetch_page.response", url, content)
     page_path.write_text(content, encoding="utf-8")
     return content
 
@@ -2533,6 +2539,8 @@ def extract_index_links(
     applied. Accepted links retain document order and duplicates; callers may
     deduplicate them after recording diagnostics.
     """
+    if not isinstance(index_html, str) or not index_html.strip():
+        raise CrawlerParserError("extract_index_links", index_url or src["start_url"], index_html)
     soup = _parse_index_soup(index_html)
     include_patterns = src.get("include_patterns")
     if include_patterns:
@@ -2683,6 +2691,8 @@ def harvest_source(src: dict, force: bool = False):
     logging.info("Harvest: %s — %s", src["name"], start_url)
     if index_html is None:
         last_exc = None
+        total_raw_candidates = 0
+        total_accepted_links = 0
         for candidate_idx, candidate_url in enumerate(start_candidates, start=1):
             logging.info(
                 "Index candidate %d/%d for %s: %s",
@@ -2705,6 +2715,7 @@ def harvest_source(src: dict, force: bool = False):
                 candidate_links, candidate_raw_links, candidate_accepted_links = extract_index_links(
                     candidate_html, src, index_url=candidate_url
                 )
+                SOURCE_SUMMARY[src_name]["index_fetch_status"] = "fetched"
                 candidate_used_cache = False
                 if candidate_accepted_links == 0 and prior_candidate_html is not None:
                     cached_links, cached_raw_links, cached_accepted_links = extract_index_links(
@@ -2723,6 +2734,8 @@ def harvest_source(src: dict, force: bool = False):
                         candidate_accepted_links = cached_accepted_links
                         candidate_used_cache = True
                         candidate_cache_path.write_text(prior_candidate_html, encoding="utf-8")
+                total_raw_candidates += candidate_raw_links
+                total_accepted_links += candidate_accepted_links
                 candidate_attempt = {
                     "url": candidate_url,
                     "raw_link_candidates": candidate_raw_links,
@@ -2738,11 +2751,15 @@ def harvest_source(src: dict, force: bool = False):
                         src.get("name"),
                         candidate_url,
                     )
+                    # Retain the last valid index so an all-filtered crawl is
+                    # diagnosed as discovery failure rather than hashed as None.
+                    index_html = candidate_html
+                    links = candidate_links
                     continue
                 index_html = candidate_html
                 links = candidate_links
-                SOURCE_SUMMARY[src_name]["raw_link_candidates"] = candidate_raw_links
-                SOURCE_SUMMARY[src_name]["accepted_links"] = candidate_accepted_links
+                SOURCE_SUMMARY[src_name]["raw_link_candidates"] = total_raw_candidates
+                SOURCE_SUMMARY[src_name]["accepted_links"] = total_accepted_links
                 SOURCE_SUMMARY[src_name]["index_fetch_status"] = "fetched"
                 if candidate_url != src["start_url"]:
                     logging.info("Index fetched via fallback URL for %s: %s", src.get("name"), candidate_url)
@@ -2758,11 +2775,32 @@ def harvest_source(src: dict, force: bool = False):
                     "error": str(exc),
                 })
                 logging.warning("Index candidate failed for %s: %s (%s)", src.get("name"), candidate_url, exc)
+            except Exception as exc:
+                # Parser/library failures are crawler defects, not upstream
+                # transport failures. Preserve whatever earlier attempts saw.
+                last_exc = exc
+                SOURCE_SUMMARY[src_name]["index_attempts"].append({
+                    "url": candidate_url,
+                    "raw_link_candidates": 0,
+                    "accepted_links": 0,
+                    "error": str(exc),
+                })
+                SOURCE_SUMMARY[src_name]["index_fetch_status"] = "parser_error"
+                SOURCE_SUMMARY[src_name]["last_error"] = str(exc)
+                logging.exception("Index crawler/parser failed for %s: %s", src.get("name"), candidate_url)
+
+        SOURCE_SUMMARY[src_name]["raw_link_candidates"] = total_raw_candidates
+        SOURCE_SUMMARY[src_name]["accepted_links"] = total_accepted_links
 
         all_candidates_failed = SOURCE_SUMMARY[src_name]["index_attempts"] and all(
             "error" in attempt for attempt in SOURCE_SUMMARY[src_name]["index_attempts"]
         )
-        if index_html is None and last_exc is not None and all_candidates_failed:
+        if (
+            index_html is None
+            and last_exc is not None
+            and all_candidates_failed
+            and SOURCE_SUMMARY[src_name]["index_fetch_status"] != "parser_error"
+        ):
             SOURCE_SUMMARY[src_name]["index_fetch_status"] = "failed"
             SOURCE_SUMMARY[src_name]["last_error"] = str(last_exc)
             try:
@@ -2875,7 +2913,15 @@ def harvest_source(src: dict, force: bool = False):
                     )
                     return []
 
+        if index_html is None and SOURCE_SUMMARY[src_name]["index_fetch_status"] == "parser_error":
+            return []
+
     # An unchanged index must still be parsed so retryable article URLs are revisited.
+    if not isinstance(index_html, str) or not index_html.strip():
+        exc = CrawlerParserError("harvest_source.index_hash", start_url, index_html)
+        SOURCE_SUMMARY[src_name]["index_fetch_status"] = "parser_error"
+        SOURCE_SUMMARY[src_name]["last_error"] = str(exc)
+        return []
     idx_digest = hashlib.sha256(index_html.encode("utf-8")).hexdigest()
     ih = STATE.setdefault("index_hash", {})
     if not force and ih.get(src["start_url"]) == idx_digest:
@@ -3099,7 +3145,8 @@ def write_source_health_report(sources: list[dict]) -> None:
         raw_candidates = int(summary.get("raw_link_candidates", 0) or 0)
         accepted_links = int(summary.get("accepted_links", 0) or 0)
         source_discovery = discovery_state.setdefault(name, {})
-        fetch_failed = status in {"failed", "parser_error", "not_attempted"}
+        fetch_failed = status in {"failed", "not_attempted"}
+        parser_failed = status == "parser_error"
         discovery_failed: bool | None = None
         if status == "fetched":
             discovery_failed = raw_candidates == 0 or accepted_links == 0
@@ -3122,6 +3169,14 @@ def write_source_health_report(sources: list[dict]) -> None:
                 else None
             )
         article_failed = (accepted == 0) if attempted > 0 else None
+        if status == "parser_error":
+            failure_class = "crawler_parser_error"
+        elif fetch_failed:
+            failure_class = "source_fetch_failure"
+        elif discovery_failed is True and raw_candidates > 0 and accepted_links == 0:
+            failure_class = "discovery_filter_failure"
+        else:
+            failure_class = None
 
         def update_streak(streak_map: dict, failed: bool | None) -> int:
             previous = int(streak_map.get(name, 0) or 0)
@@ -3136,7 +3191,7 @@ def write_source_health_report(sources: list[dict]) -> None:
             discovery_streak = update_streak(discovery_streaks, discovery_failed)
             article_streak = update_streak(article_streaks, article_failed)
             previous_legacy = int(legacy_streaks.get(name, 0) or 0)
-            any_failure = fetch_failed or discovery_failed is True or article_failed is True
+            any_failure = parser_failed or fetch_failed or discovery_failed is True or article_failed is True
             legacy_streaks[name] = previous_legacy + 1 if any_failure else 0
         else:
             fetch_streak = int(fetch_streaks.get(name, 0) or 0)
@@ -3146,6 +3201,7 @@ def write_source_health_report(sources: list[dict]) -> None:
         rows.append({
             "source": name,
             "index_fetch_status": status,
+            "failure_class": failure_class,
             "consecutive_failures": legacy_streaks[name],
             "consecutive_fetch_failures": fetch_streak,
             "consecutive_discovery_failures": discovery_streak,

--- a/scripts/http_client.py
+++ b/scripts/http_client.py
@@ -47,6 +47,19 @@ class SeleniumUnavailable(RuntimeError):
     """Raised when Selenium fallback cannot be executed."""
 
 
+class CrawlerParserError(RuntimeError):
+    """Raised when an internal crawler stage returns unusable page content."""
+
+    def __init__(self, stage: str, url: str, value: Any):
+        self.stage = stage
+        self.url = url
+        self.returned_type = type(value).__name__
+        super().__init__(
+            f"crawler/parser error at {stage} for {url}: "
+            f"expected non-empty str, got {self.returned_type}"
+        )
+
+
 @dataclass
 class WarmupConfig:
     """Configuration for a warm-up request before regular traffic."""
@@ -582,13 +595,17 @@ class HostClient:
         try:
             driver = webdriver.Chrome(options=self._build_chrome_options())
             self._apply_selenium_rendering(driver, url)
-            html = driver.page_source or ""
+            html = driver.page_source
             self._apply_selenium_cookies(driver.get_cookies())
+            if not isinstance(html, str):
+                raise CrawlerParserError("selenium.page_source", url, html)
             if html.strip():
                 LOGGER.info("Selenium HTML fetch success for %s", self.host)
                 return html
             LOGGER.warning("Selenium HTML fetch returned empty page for %s", self.host)
             return None
+        except CrawlerParserError:
+            raise
         except Exception as exc:
             LOGGER.warning("Selenium HTML fetch failed for %s: %s", self.host, exc)
             return None

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -154,6 +154,7 @@ def merge_current_crawl_metrics(
             "attempted_articles",
             "accepted_articles",
             "consecutive_fetch_failures",
+            "consecutive_parser_failures",
             "consecutive_discovery_failures",
             "consecutive_article_failures",
         )
@@ -272,6 +273,7 @@ def classify_source_health(
         error = row.get("last_error")
         legacy_streak = int(row.get("consecutive_failures") or 0)
         fetch_streak = int(row.get("consecutive_fetch_failures", legacy_streak) or 0)
+        parser_streak = int(row.get("consecutive_parser_failures", legacy_streak) or 0)
         discovery_streak = int(row.get("consecutive_discovery_failures") or 0)
         article_streak = int(
             row.get("consecutive_article_failures", legacy_streak) or 0
@@ -284,16 +286,17 @@ def classify_source_health(
         article_outage = attempted > 0 and accepted == 0
         failure_kind = "article crawl failed" if article_outage else status
         hard_status = status in {"failed", "parser_error", "not_attempted"}
+        hard_streak = parser_streak if status == "parser_error" else fetch_streak
         if status == "skipped_selection":
             continue
-        elif hard_status and fetch_streak >= failure_threshold:
+        elif hard_status and hard_streak >= failure_threshold:
             detail = f" ({error})" if error else ""
             failures.append(
-                f"{name}: {status} for {fetch_streak} consecutive runs{detail}"
+                f"{name}: {status} for {hard_streak} consecutive runs{detail}"
             )
         elif hard_status:
             warnings.append(
-                f"{name}: transient {status} (run {fetch_streak}/{failure_threshold})"
+                f"{name}: transient {status} (run {hard_streak}/{failure_threshold})"
             )
         elif discovery_streak:
             detail = (

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,6 +1,7 @@
 import pathlib
 import sys
 import time
+import types
 
 import pytest
 import requests
@@ -11,11 +12,45 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from scripts.http_client import (
     DEFAULT_USER_AGENT,
     HostClient,
+    CrawlerParserError,
     RequestStrategy,
     SourceTemporarilyUnavailable,
     WarmupConfig,
     build_strategy_registry,
 )
+
+
+def test_selenium_non_string_page_source_is_crawler_parser_error(monkeypatch):
+    client = HostClient(
+        "example.com", RequestStrategy(selenium_fallback=True), {}
+    )
+
+    class Driver:
+        page_source = {"unexpected": "payload"}
+
+        def get(self, url):
+            pass
+
+        def get_cookies(self):
+            return []
+
+        def quit(self):
+            pass
+
+    selenium = types.ModuleType("selenium")
+    selenium.webdriver = types.SimpleNamespace(Chrome=lambda options: Driver())
+    monkeypatch.setitem(sys.modules, "selenium", selenium)
+    monkeypatch.setattr("scripts.http_client.importlib.util.find_spec", lambda name: object())
+    monkeypatch.setattr(client, "_build_chrome_options", lambda: object())
+    monkeypatch.setattr(client, "_apply_selenium_rendering", lambda driver, url: driver.get(url))
+
+    with pytest.raises(CrawlerParserError) as exc_info:
+        client.fetch_html_with_selenium("https://example.com/index")
+
+    message = str(exc_info.value)
+    assert "selenium.page_source" in message
+    assert "https://example.com/index" in message
+    assert "dict" in message
 
 
 class DummyResponse:

--- a/tests/test_metrics_tool.py
+++ b/tests/test_metrics_tool.py
@@ -384,6 +384,24 @@ def test_failed_crawl_is_prominent_despite_recent_retained_content():
     assert row["discovery_recency_status"] == "recent"
 
 
+def test_repeated_parser_error_uses_parser_streak_for_strict_validation():
+    rows = [{
+        "source": "broken parser",
+        "index_fetch_status": "parser_error",
+        "consecutive_fetch_failures": 0,
+        "consecutive_parser_failures": 3,
+        "consecutive_failures": 3,
+        "last_error": "parser exploded",
+    }]
+
+    failures, warnings = classify_source_health(rows, failure_threshold=3)
+
+    assert failures == [
+        "broken parser: parser_error for 3 consecutive runs (parser exploded)"
+    ]
+    assert warnings == []
+
+
 def test_successful_discovery_without_new_article_is_healthy():
     row = _merged_report(
         None,

--- a/tests/test_retention_and_cache.py
+++ b/tests/test_retention_and_cache.py
@@ -192,6 +192,31 @@ def test_unchanged_index_preserves_zero_accepted_discovery_failure(tmp_path, mon
     assert row["last_successful_discovery_at"] == "2026-08-06T12:00:00+00:00"
 
 
+def test_filtered_attempts_retain_aggregate_raw_candidates(tmp_path, monkeypatch):
+    health_path = tmp_path / "health.json"
+    summaries = defaultdict(dict)
+    summaries["filtered"] = {
+        "index_fetch_status": "fetched",
+        "raw_link_candidates": 37,
+        "accepted_links": 0,
+        "index_attempts": [
+            {"url": "https://example.test/a", "raw_link_candidates": 20, "accepted_links": 0},
+            {"url": "https://example.test/b", "raw_link_candidates": 17, "accepted_links": 0},
+        ],
+    }
+    monkeypatch.setattr(aggregate, "SOURCE_HEALTH_JSON", health_path)
+    monkeypatch.setattr(aggregate, "SOURCE_SUMMARY", summaries)
+    monkeypatch.setattr(aggregate, "STATE", {})
+
+    aggregate.write_source_health_report([{"name": "filtered", "enabled": True}])
+
+    row = json.loads(health_path.read_text())["sources"][0]
+    assert row["raw_link_candidates"] == 37
+    assert row["accepted_links"] == 0
+    assert row["failure_class"] == "discovery_filter_failure"
+    assert [attempt["raw_link_candidates"] for attempt in row["index_attempts"]] == [20, 17]
+
+
 def test_failed_discovery_does_not_advance_last_success_timestamp(tmp_path, monkeypatch):
     health_path = tmp_path / "health.json"
     state_path = tmp_path / "state.json"

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -175,6 +175,8 @@ def test_parser_exception_is_reported_as_crawler_parser_error(monkeypatch, tmp_p
     row = json.loads((tmp_path / "health.json").read_text())["sources"][0]
     assert row["index_fetch_status"] == "parser_error"
     assert row["failure_class"] == "crawler_parser_error"
+    assert row["consecutive_fetch_failures"] == 0
+    assert row["consecutive_parser_failures"] == 1
     assert row["index_attempts"][0]["error"] == "parser exploded"
 
 

--- a/tests/test_source_contracts.py
+++ b/tests/test_source_contracts.py
@@ -160,6 +160,24 @@ def test_fallback_skips_anchor_page_without_accepted_articles(monkeypatch, tmp_p
     ]
 
 
+def test_parser_exception_is_reported_as_crawler_parser_error(monkeypatch, tmp_path):
+    source = {
+        "name": "Broken parser fixture",
+        "start_url": "https://example.test/news",
+        "base_url": "https://example.test/",
+    }
+    monkeypatch.setattr(aggregate, "fetch_page", lambda *args, **kwargs: "<html>valid</html>")
+    monkeypatch.setattr(aggregate, "_parse_index_soup", lambda html: (_ for _ in ()).throw(ValueError("parser exploded")))
+    monkeypatch.setattr(aggregate, "SOURCE_HEALTH_JSON", tmp_path / "health.json")
+
+    assert aggregate.harvest_source(source, force=True) == []
+    aggregate.write_source_health_report([source])
+    row = json.loads((tmp_path / "health.json").read_text())["sources"][0]
+    assert row["index_fetch_status"] == "parser_error"
+    assert row["failure_class"] == "crawler_parser_error"
+    assert row["index_attempts"][0]["error"] == "parser exploded"
+
+
 def test_challenge_response_does_not_overwrite_valid_cached_index(monkeypatch, tmp_path):
     primary = "https://example.test/news"
     fallback = "https://example.test/fallback"


### PR DESCRIPTION
### Motivation
- Prevent obscure `.encode()`/parsing failures by validating that fetched index content is a non-empty string before hashing or parsing. 
- Make crawler defects visible by surfacing a dedicated error when an internal crawler stage (including Selenium fallback) returns an unexpected value. 
- Preserve observed discovery evidence across fallback attempts so diagnostics report what was actually seen rather than being overwritten by subsequent failures.

### Description
- Add `CrawlerParserError` in `scripts/http_client.py` and raise it when Selenium `page_source` (or other internal crawler stages) returns a non-string or empty value. 
- Validate returned content in `fetch_page` and `extract_index_links` and raise `CrawlerParserError` for non-string/empty results to avoid downstream `.encode()` errors. 
- In `harvest_source`, retain each attempt's `raw_link_candidates`, `accepted_links`, and `error`, aggregate `raw_link_candidates`/`accepted_links` across attempts, and avoid overwriting observed counts with zeros when final discovery fails. 
- Classify failures in the source health report as `source_fetch_failure`, `crawler_parser_error`, or `discovery_filter_failure`, and ensure parser errors do not increment source-fetch failure streaks. 
- Add regression tests covering a non-string Selenium result, a parser exception, and an index with multiple raw candidates but zero accepted links in `tests/test_http_client.py`, `tests/test_source_contracts.py`, and `tests/test_retention_and_cache.py` respectively.

### Testing
- Ran `python -m py_compile scripts/aggregate.py scripts/http_client.py` which completed successfully. 
- Ran full unit test suite with `pytest -q` and observed `155 passed` (with three existing BeautifulSoup XML-as-HTML warnings). 
- Executed the targeted contract and regression tests and verified the new tests exercise the non-string Selenium case, parser exception handling, and aggregated raw-candidate reporting (all passing as part of the suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7633ce7ad8832cbd0cea9d9a0640a7)