### PR TITLE
Fix live discovery for Interfax, ERZ, and Metalinfo

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -725,6 +725,18 @@ AMP_QUERY_WHITELIST = {"ria.ru", "realty.ria.ru", "realty.interfax.ru", "interfa
 SHORT_CONTENT_WORDS = 60
 
 
+def _access_challenge_label(content: str | None) -> str | None:
+    lowered = content[:12000].casefold() if isinstance(content, str) else ""
+    for marker, label in (
+        ("servicepipe.tech/loaders/", "Servicepipe browser challenge"),
+        ("js-challenge-script-", "JavaScript access challenge"),
+        ("ваш браузер не смог пройти", "JavaScript access challenge"),
+    ):
+        if marker in lowered:
+            return label
+    return None
+
+
 def _is_short_content(text: str | None) -> bool:
     return _word_count(text or "") < SHORT_CONTENT_WORDS
 
@@ -777,6 +789,15 @@ def fetch_page(url: str, src: dict | None = None) -> str:
             headers={"User-Agent": USER_AGENT},
             timeout=REQUEST_TIMEOUT,
         ).text
+    # Servicepipe commonly answers non-browser clients with HTTP 200, so the
+    # HTTP-error fallback above never runs. Render configured sources before a
+    # challenge page is cached and mistaken for an empty index.
+    if _access_challenge_label(content):
+        client = get_host_client(url, src)
+        if client and client.strategy.selenium_fallback:
+            rendered = client.fetch_html_with_selenium(url)
+            if rendered and not _access_challenge_label(rendered):
+                content = rendered
     if not isinstance(content, str) or not content.strip():
         raise CrawlerParserError("fetch_page.response", url, content)
     page_path.write_text(content, encoding="utf-8")
@@ -2355,7 +2376,8 @@ def _api_endpoints(src: dict) -> list[str]:
     endpoint = src.get("api_endpoint")
     pages = int(src.get("api_endpoint_pages", 1))
     if pages <= 1:
-        return [endpoint] if endpoint else []
+        endpoints = [endpoint] if endpoint else []
+        return _add_api_current_date(endpoints, src)
     start = int(src.get("api_page_start", 1))
     page_param = str(src.get("api_page_param", "page"))
     endpoints = []
@@ -2365,7 +2387,29 @@ def _api_endpoints(src: dict) -> list[str]:
         else:
             separator = "&" if "?" in endpoint else "?"
             endpoints.append(f"{endpoint}{separator}{page_param}={page}")
-    return endpoints
+    return _add_api_current_date(endpoints, src)
+
+
+def _add_api_current_date(endpoints: list[str], src: dict) -> list[str]:
+    """Add a source-configured, moving upper date bound to API requests.
+
+    Some archive APIs do not default their upper bound to today.  Keeping this
+    opt-in makes the pagination machinery generic while matching the request
+    made by the site's own news UI.
+    """
+    param = src.get("api_current_date_param")
+    if not param:
+        return endpoints
+    date_format = str(src.get("api_current_date_format", "%d.%m.%Y"))
+    current_date = datetime.now(MSK).strftime(date_format)
+    bounded = []
+    for endpoint in endpoints:
+        parsed = urlparse(endpoint)
+        query = parse_qsl(parsed.query, keep_blank_values=True)
+        if not any(key == param for key, _ in query):
+            query.append((str(param), current_date))
+        bounded.append(parsed._replace(query=urlencode(query)).geturl())
+    return bounded
 
 
 def harvest_json_source(src: dict, force: bool = False):
@@ -2935,6 +2979,13 @@ def _is_feed_index(src: dict, index_url: str) -> bool:
 
 def _extract_index_candidate(index_text: str, src: dict, index_url: str):
     """Parse a live or cached index with the parser configured for its format."""
+    challenge_label = _access_challenge_label(index_text)
+    if challenge_label:
+        # A browser challenge returned with HTTP 200 is an upstream access
+        # failure, not malformed XML and not an empty HTML listing.
+        raise SourceTemporarilyUnavailable(
+            f"{challenge_label} returned instead of discovery content: {index_url}"
+        )
     if not _is_feed_index(src, index_url):
         links, raw_count, accepted_count = extract_index_links(
             index_text, src, index_url=index_url

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -798,6 +798,18 @@ def fetch_page(url: str, src: dict | None = None) -> str:
             rendered = client.fetch_html_with_selenium(url)
             if rendered and not _access_challenge_label(rendered):
                 content = rendered
+        challenge_label = _access_challenge_label(content)
+        if challenge_label:
+            if page_path.exists():
+                logging.warning(
+                    "%s unresolved for %s — preserving and using cached copy",
+                    challenge_label,
+                    url,
+                )
+                return page_path.read_text(encoding="utf-8")
+            raise SourceTemporarilyUnavailable(
+                f"{challenge_label} returned instead of discovery content: {url}"
+            )
     if not isinstance(content, str) or not content.strip():
         raise CrawlerParserError("fetch_page.response", url, content)
     page_path.write_text(content, encoding="utf-8")

--- a/sources.json
+++ b/sources.json
@@ -261,7 +261,13 @@
       "warmup": {
         "url": "https://www.interfax-russia.ru/realty/",
         "capture_cookies": true
-      }
+      },
+      "selenium_fallback": true,
+      "selenium_wait": 8,
+      "selenium_wait_for": [
+        "a[href*='/realty/news/']"
+      ],
+      "capture_cookies": true
     }
   },
   {
@@ -368,6 +374,8 @@
     "mode": "api",
     "structured_adapter": "erz",
     "api_endpoint": "https://erzrf.ru/erz-rest/api/v1/news/list/short?min=0&max=100",
+    "api_current_date_param": "periodTo",
+    "api_current_date_format": "%d.%m.%Y",
     "html_fallback_on_empty_api": true,
     "include_patterns": [
       "/news/"

--- a/tests/test_api_harvest.py
+++ b/tests/test_api_harvest.py
@@ -7,6 +7,26 @@ from pathlib import Path
 from scripts import aggregate
 
 
+def test_erz_endpoint_uses_same_current_upper_bound_as_public_news_page(monkeypatch):
+    real_datetime = aggregate.datetime
+
+    class FixedDatetime(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 8, 8, tzinfo=tz)
+
+    src = {
+        "api_endpoint": "https://erzrf.ru/erz-rest/api/v1/news/list/short?min=0&max=100",
+        "api_current_date_param": "periodTo",
+        "api_current_date_format": "%d.%m.%Y",
+    }
+    monkeypatch.setattr(aggregate, "datetime", FixedDatetime)
+
+    assert aggregate._api_endpoints(src) == [
+        "https://erzrf.ru/erz-rest/api/v1/news/list/short?min=0&max=100&periodTo=08.08.2026"
+    ]
+
+
 class DummyResponse:
     def __init__(self, payload):
         self._payload = payload

--- a/tests/test_interfax_feed.py
+++ b/tests/test_interfax_feed.py
@@ -116,6 +116,40 @@ def test_empty_feed_parse_has_distinct_diagnostic(monkeypatch):
     assert attempt["failure_kind"] == "feed_empty_parse"
 
 
+def test_live_servicepipe_pages_are_reported_as_access_failures(monkeypatch):
+    challenge = '''<!doctype html><script
+      src="https://servicepipe.tech/loaders/example.js"></script>'''
+    monkeypatch.setattr(aggregate, "fetch_page", lambda url, src=None: challenge)
+
+    assert aggregate.harvest_source(SOURCE, force=True) == []
+    attempts = aggregate.SOURCE_SUMMARY[SOURCE["name"]]["index_attempts"]
+    assert [attempt["failure_kind"] for attempt in attempts] == [
+        "feed_fetch_failure", "fetch_failure"
+    ]
+    assert all("Servicepipe browser challenge" in attempt["error"] for attempt in attempts)
+
+
+def test_http_200_servicepipe_response_uses_configured_browser(monkeypatch, tmp_path):
+    challenge = '<script src="https://servicepipe.tech/loaders/example.js"></script>'
+    rendered = (FIXTURES / "saved-news.html").read_text()
+
+    class Strategy:
+        selenium_fallback = True
+
+    class Client:
+        strategy = Strategy()
+
+        def fetch_html_with_selenium(self, url):
+            return rendered
+
+    monkeypatch.setattr(aggregate, "PAGES_DIR", tmp_path)
+    monkeypatch.setattr(aggregate, "http_get", lambda *args, **kwargs: (challenge, {}))
+    monkeypatch.setattr(aggregate, "get_host_client", lambda *args, **kwargs: Client())
+
+    assert aggregate.fetch_page(FEED_URL, src=SOURCE) == rendered
+    assert "servicepipe.tech" not in (tmp_path / aggregate.cache_key_for(FEED_URL)).read_text()
+
+
 def test_cached_feed_uses_feed_parser_and_content_fallback(monkeypatch, tmp_path):
     feed = (FIXTURES / "official-feed.xml").read_text()
     monkeypatch.setattr(aggregate, "PAGES_DIR", tmp_path)

--- a/tests/test_interfax_feed.py
+++ b/tests/test_interfax_feed.py
@@ -150,6 +150,52 @@ def test_http_200_servicepipe_response_uses_configured_browser(monkeypatch, tmp_
     assert "servicepipe.tech" not in (tmp_path / aggregate.cache_key_for(FEED_URL)).read_text()
 
 
+@pytest.mark.parametrize("rendered", [None, '<script src="https://servicepipe.tech/loaders/still-blocked.js"></script>'])
+def test_unresolved_http_200_challenge_preserves_known_good_cache(
+    monkeypatch, tmp_path, rendered
+):
+    challenge = '<script src="https://servicepipe.tech/loaders/example.js"></script>'
+    feed = (FIXTURES / "official-feed.xml").read_text()
+    cache_path = tmp_path / aggregate.cache_key_for(FEED_URL)
+    cache_path.write_text(feed)
+
+    class Strategy:
+        selenium_fallback = True
+
+    class Client:
+        strategy = Strategy()
+
+        def fetch_html_with_selenium(self, url):
+            return rendered
+
+    monkeypatch.setattr(aggregate, "PAGES_DIR", tmp_path)
+    monkeypatch.setattr(aggregate, "http_get", lambda *args, **kwargs: (challenge, {}))
+    monkeypatch.setattr(aggregate, "get_host_client", lambda *args, **kwargs: Client())
+
+    assert aggregate.fetch_page(FEED_URL, src=SOURCE) == feed
+    assert cache_path.read_text() == feed
+
+
+def test_unresolved_http_200_challenge_without_cache_is_access_failure(
+    monkeypatch, tmp_path
+):
+    challenge = '<script src="https://servicepipe.tech/loaders/example.js"></script>'
+
+    class Strategy:
+        selenium_fallback = False
+
+    class Client:
+        strategy = Strategy()
+
+    monkeypatch.setattr(aggregate, "PAGES_DIR", tmp_path)
+    monkeypatch.setattr(aggregate, "http_get", lambda *args, **kwargs: (challenge, {}))
+    monkeypatch.setattr(aggregate, "get_host_client", lambda *args, **kwargs: Client())
+
+    with pytest.raises(aggregate.SourceTemporarilyUnavailable, match="Servicepipe"):
+        aggregate.fetch_page(FEED_URL, src=SOURCE)
+    assert not (tmp_path / aggregate.cache_key_for(FEED_URL)).exists()
+
+
 def test_cached_feed_uses_feed_parser_and_content_fallback(monkeypatch, tmp_path):
     feed = (FIXTURES / "official-feed.xml").read_text()
     monkeypatch.setattr(aggregate, "PAGES_DIR", tmp_path)

--- a/tests/test_metalinfo_feed.py
+++ b/tests/test_metalinfo_feed.py
@@ -51,6 +51,19 @@ def test_numeric_normalization_does_not_rewrite_an_external_feed_link():
     assert aggregate.parse_rss_atom_index(feed, SOURCE, index_url=FEED_URL) == []
 
 
+def test_live_javascript_block_page_is_transport_diagnostic_not_xml_error(monkeypatch):
+    blocked = '''<!doctype html><script
+      src="/js-challenge-script-abc.js"></script><h1>Ваш браузер не смог пройти проверку.</h1>'''
+    monkeypatch.setattr(aggregate, "fetch_page", lambda url, src=None: blocked)
+
+    assert aggregate.harvest_source(SOURCE, force=True) == []
+    attempts = aggregate.SOURCE_SUMMARY[SOURCE["name"]]["index_attempts"]
+    assert attempts[0]["failure_kind"] == "feed_fetch_failure"
+    assert attempts[1]["failure_kind"] == "fetch_failure"
+    assert all("JavaScript access challenge" in attempt["error"] for attempt in attempts)
+    assert aggregate.SOURCE_SUMMARY[SOURCE["name"]]["index_fetch_status"] == "failed"
+
+
 def test_adequate_feed_content_fallback_reports_article_degradation(monkeypatch):
     feed = (FIXTURES / "index.rss").read_text()
     monkeypatch.setattr(aggregate, "fetch_page", lambda url, src=None: feed if url == FEED_URL else (_ for _ in ()).throw(requests.ConnectionError("blocked")))


### PR DESCRIPTION
### Motivation
- Interfax RSS/HTML endpoints were returning an HTTP-200 Servicepipe/JavaScript loader page instead of feed/listing content, causing zero raw candidates.
- Metalinfo's RSS/HTML endpoints returned JavaScript challenge/blocked pages (HTTP 503) and were treated as parser/XML failures rather than upstream access problems.
- ERZ's structured API requests were unbounded and returned a historical October slice; the site frontend includes an upper-date bound that must be mirrored to discover current items.

### Description
- Add challenge detection and labeling with `_access_challenge_label` and use it to detect Servicepipe/JS challenge pages early. (`scripts/aggregate.py`)
- Render challenge pages via the existing Selenium fallback in `fetch_page` before caching, and treat unresolved challenge documents as upstream `SourceTemporarilyUnavailable` rather than parser errors by raising when appropriate. (`scripts/aggregate.py`) 
- Add opt-in API request bounding with `_add_api_current_date` and wire it into `_api_endpoints` so sources can append a moving `periodTo` (or other) parameter; configure ERZ to send `periodTo=dd.MM.YYYY`. (`scripts/aggregate.py`, `sources.json`)
- Enable and configure Selenium discovery warmup/wait for Interfax so the site’s JS loader can be resolved when possible, and keep existing generic feed/API machinery unchanged unless source-specific configuration is present. (`sources.json`)
- Add focused regression tests that assert Servicepipe/JS challenge handling and the ERZ date-parameter behavior. (`tests/test_interfax_feed.py`, `tests/test_metalinfo_feed.py`, `tests/test_api_harvest.py`)

### Testing
- Ran the focused suite: `pytest -q tests/test_interfax_feed.py tests/test_metalinfo_feed.py tests/test_api_harvest.py` and observed all tests pass (25 passed).
- Ran the full test suite with `pytest -q` and observed success (189 passed, 3 pre-existing XML-parsing warnings only).
- Performed live HTTP probes against Interfax, Metalinfo and ERZ to confirm root causes: Interfax returned Servicepipe loader pages (HTTP 200), Metalinfo returned JavaScript challenge pages (HTTP 503), and the ERZ unbounded endpoint returned the historical slice; after the change ERZ endpoints are constructed with the current `periodTo` parameter.
- Added unit tests for the new behaviors and verified they run and pass as part of the above test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77b4a187c0832caf25afbbc05f90fe)