### PR TITLE
Add GitHub Pages artifact upload and deploy job to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
@@ -101,8 +103,29 @@ jobs:
           git commit -m "Update unified feed [skip ci]" || echo "No changes"
           git push
 
+      - name: Upload GitHub Pages artifact
+        if: steps.validation.outcome == 'success'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+
       - name: Report validation failure
         if: steps.validation.outcome == 'failure'
         run: |
           echo "Candidate failed feed validation; prior feed was retained." >&2
           exit 1
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
### Motivation
- Publish the generated `docs` output (unified feed and source-health) to GitHub Pages from CI and ensure the workflow has the necessary permissions for writing outputs and deploying pages.

### Description
- Grant `contents: write` permission to the `build` job and add `pages: write` and `id-token: write` for a new `deploy` job. 
- Upload the generated `docs` directory using `actions/upload-pages-artifact@v5` when `steps.validation.outcome == 'success'` via a new `Upload GitHub Pages artifact` step. 
- Add a `deploy` job that `needs: build`, sets `environment: github-pages`, and runs `actions/deploy-pages@v5` to deploy the uploaded artifact. 
- Keep existing steps that commit updated feed/state and report validation failure unchanged.

### Testing
- No automated unit tests were added or modified in this change. 
- Workflow-level validation is expected to be exercised by running the GitHub Actions workflow in CI (no automated run results are included in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78ce86e214832c831f97f5ea7e9ab3)